### PR TITLE
Expose GUID instructions in the WinRT builder API

### DIFF
--- a/src/UIAutomation/FunctionalTests/pch.h
+++ b/src/UIAutomation/FunctionalTests/pch.h
@@ -3,6 +3,13 @@
 
 #pragma once
 
+// The following macro tells the Windows header files to define GUIDs, not just declare them.
+// This is necessary for the UI Automation GUIDs that we use in GUID-related tests.
+// Normally this macro isn't necessary in application code, because the Windows SDK provides
+// static libraries that define all of the commonly used GUIDs. But none of those libraries
+// include this category of UI Automation GUID.
+#define INITGUID
+
 #include <unknwn.h>
 #include <Windows.h>
 #include <uiautomation.h>

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.cpp
@@ -102,6 +102,19 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return make<AutomationRemoteRect>(newId, *this);
     }
 
+    bool AutomationRemoteOperation::IsGuidSupported() const
+    {
+        return m_remoteOperation.IsOpcodeSupported(static_cast<uint32_t>(bytecode::InstructionType::NewGuid));
+    }
+
+    winrt::AutomationRemoteGuid AutomationRemoteOperation::NewGuid(const winrt::guid& initialValue)
+    {
+        const auto newId = GetNextId();
+        InsertInstruction(bytecode::NewGuid{ newId, initialValue });
+
+        return make<AutomationRemoteGuid>(newId, *this);
+    }
+
     winrt::AutomationRemoteArray AutomationRemoteOperation::NewArray()
     {
         const auto newId = GetNextId();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.h
@@ -59,6 +59,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteString NewString(hstring const& initialValue);
         winrt::AutomationRemotePoint NewPoint(Windows::Foundation::Point const& initialValue);
         winrt::AutomationRemoteRect NewRect(Windows::Foundation::Rect const& initialValue);
+        bool IsGuidSupported() const;
+        winrt::AutomationRemoteGuid NewGuid(const winrt::guid& initialValue);
         winrt::AutomationRemoteArray NewArray();
         winrt::AutomationRemoteStringMap NewStringMap();
         winrt::AutomationRemoteAnyObject NewNull();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
@@ -95,6 +95,17 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return AutomationRemoteObject::IsNotEqual<AutomationRemoteAnnotationType>(rhs);
     }
 
+    winrt::AutomationRemoteGuid AutomationRemoteAnnotationType::LookupGuid()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::LookupGuid{
+            resultId,
+            m_operandId,
+            AutomationIdentifierType_Annotation
+        });
+        return Make<AutomationRemoteGuid>(resultId);
+    }
+
     winrt::AutomationRemoteAnnotationType AutomationRemoteOperation::NewEnum(AutomationAnnotationType initialValue)
     {
         const auto resultId = GetNextId();
@@ -589,6 +600,17 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     winrt::AutomationRemoteBool AutomationRemotePropertyId::IsNotEqual(const AutomationRemotePropertyId::class_type& rhs)
     {
         return AutomationRemoteObject::IsNotEqual<AutomationRemotePropertyId>(rhs);
+    }
+
+    winrt::AutomationRemoteGuid AutomationRemotePropertyId::LookupGuid()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::LookupGuid{
+            resultId,
+            m_operandId,
+            AutomationIdentifierType_Property
+        });
+        return Make<AutomationRemoteGuid>(resultId);
     }
 
     winrt::AutomationRemotePropertyId AutomationRemoteOperation::NewEnum(AutomationPropertyId initialValue)

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/MessageBuilder.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/MessageBuilder.cpp
@@ -46,6 +46,12 @@ void MessageBuilder::WriteString(std::wstring_view val)
     WriteBytes(reinterpret_cast<const uint8_t*>(val.data()), val.size() * sizeof(wchar_t));
 }
 
+void MessageBuilder::WriteGuid(const GUID& val)
+{
+    static_assert(sizeof(GUID) == 16, "GUID expected to be 16 bytes");
+    WriteBytes(reinterpret_cast<const uint8_t*>(&val), sizeof(val));
+}
+
 std::vector<uint8_t> MessageBuilder::DetachBuffer()
 {
     return std::move(m_buffer);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/MessageBuilder.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/MessageBuilder.h
@@ -25,6 +25,7 @@ public:
     void WriteUnsignedInt(unsigned int);
     void WriteDouble(double);
     void WriteString(std::wstring_view);
+    void WriteGuid(const GUID&);
 
     // Takes ownership of the buffer that contains the serialized representation of all values
     // that have been written to the builder thus far.

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -115,6 +115,16 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteDouble GetY();
     }
 
+    runtimeclass AutomationRemoteGuid : AutomationRemoteObject
+    {
+        void Set(AutomationRemoteGuid rhs);
+        AutomationRemoteBool IsEqual(AutomationRemoteGuid rhs);
+        AutomationRemoteBool IsNotEqual(AutomationRemoteGuid rhs);
+
+        AutomationRemoteAnnotationType LookupAnnotationType();
+        AutomationRemotePropertyId LookupPropertyId();
+    }
+
     runtimeclass AutomationRemoteArray : AutomationRemoteObject
     {
         void Set(AutomationRemoteArray rhs);
@@ -195,6 +205,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemotePoint AsPoint();
         AutomationRemoteBool IsRect();
         AutomationRemoteRect AsRect();
+        AutomationRemoteBool IsGuid();
+        AutomationRemoteGuid AsGuid();
         AutomationRemoteBool IsArray();
         AutomationRemoteArray AsArray();
         AutomationRemoteBool IsStringMap();
@@ -270,6 +282,7 @@ namespace Microsoft.UI.UIAutomation
         void Set(AutomationRemoteAnnotationType rhs);
         AutomationRemoteBool IsEqual(AutomationRemoteAnnotationType rhs);
         AutomationRemoteBool IsNotEqual(AutomationRemoteAnnotationType rhs);
+        AutomationRemoteGuid LookupGuid();
     };
 
     enum AutomationBulletStyle
@@ -731,6 +744,7 @@ namespace Microsoft.UI.UIAutomation
         void Set(AutomationRemotePropertyId rhs);
         AutomationRemoteBool IsEqual(AutomationRemotePropertyId rhs);
         AutomationRemoteBool IsNotEqual(AutomationRemotePropertyId rhs);
+        AutomationRemoteGuid LookupGuid();
     };
 
     enum AutomationRowOrColumnMajor
@@ -1630,6 +1644,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteString NewString(String initialValue);
         AutomationRemotePoint NewPoint(Windows.Foundation.Point initialValue);
         AutomationRemoteRect NewRect(Windows.Foundation.Rect initialValue);
+        Boolean IsGuidSupported();
+        AutomationRemoteGuid NewGuid(Guid initialValue);
         AutomationRemoteArray NewArray();
         AutomationRemoteStringMap NewStringMap();
         AutomationRemoteAnyObject NewNull();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
@@ -63,6 +63,11 @@ void RemoteOperationInstructionSerializer::Write(const UiaRect& value)
     m_builder.WriteDouble(value.height);
 }
 
+void RemoteOperationInstructionSerializer::Write(const GUID& value)
+{
+    m_builder.WriteGuid(value);
+}
+
 void RemoteOperationInstructionSerializer::Serialize(const Instruction& genericInstruction)
 {
     std::visit([&](const auto& instruction)
@@ -125,6 +130,12 @@ void RemoteOperationInstructionSerializer::Write(const NewPoint& instruction)
 }
 
 void RemoteOperationInstructionSerializer::Write(const NewRect& instruction)
+{
+    Write(instruction.resultId);
+    Write(instruction.initialValue);
+}
+
+void RemoteOperationInstructionSerializer::Write(const NewGuid& instruction)
 {
     Write(instruction.resultId);
     Write(instruction.initialValue);
@@ -427,6 +438,20 @@ void RemoteOperationInstructionSerializer::Write(const bytecode::Navigate& instr
     Write(instruction.resultId);
     Write(instruction.targetId);
     Write(instruction.directionId);
+}
+
+void RemoteOperationInstructionSerializer::Write(const bytecode::LookupId& instruction)
+{
+    Write(instruction.resultId);
+    Write(instruction.guidId);
+    Write(static_cast<int>(instruction.idType));
+}
+
+void RemoteOperationInstructionSerializer::Write(const bytecode::LookupGuid& instruction)
+{
+    Write(instruction.resultId);
+    Write(instruction.intIdId);
+    Write(static_cast<int>(instruction.idType));
 }
 
 void RemoteOperationInstructionSerializer::Write(const GetterBase& instruction)

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.h
@@ -32,6 +32,7 @@ private:
     void Write(const std::wstring& value);
     void Write(const UiaPoint& value);
     void Write(const UiaRect& value);
+    void Write(const GUID& value);
 
     // Write the instructions themselves...
     void Write(const bytecode::Nop&);
@@ -44,6 +45,7 @@ private:
     void Write(const bytecode::NewString&);
     void Write(const bytecode::NewPoint&);
     void Write(const bytecode::NewRect&);
+    void Write(const bytecode::NewGuid&);
     void Write(const bytecode::NewArray&);
     void Write(const bytecode::NewStringMap&);
     void Write(const bytecode::NewNull&);
@@ -103,6 +105,8 @@ private:
     void Write(const bytecode::Compare&);
     void Write(const bytecode::GetPropertyValue&);
     void Write(const bytecode::Navigate&);
+    void Write(const bytecode::LookupId&);
+    void Write(const bytecode::LookupGuid&);
     void Write(const bytecode::GetterBase&);
 #include "RemoteOperationInstructionSerializerMethods.g.h"
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructions.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructions.h
@@ -36,105 +36,111 @@ constexpr int MakePatternRelatedObjectMethodInstructionType(PATTERNID patternId,
 // The instruction enum value here map to the instruction opcode, defined and documented by the UIAutomation platform.
 enum class InstructionType
 {
-    Nop = 0,
-    Set,
+    Nop = 0x00,
+    Set = 0x01,
 
     // Control flow
-    ForkIfTrue,
-    ForkIfFalse,
-    Fork,
-    Halt,
+    ForkIfTrue = 0x02,
+    ForkIfFalse = 0x03,
+    Fork = 0x04,
+    Halt = 0x05,
 
     // Loops
-    NewLoopBlock,
-    EndLoopBlock,
-    BreakLoop,
-    ContinueLoop,
+    NewLoopBlock = 0x06,
+    EndLoopBlock = 0x07,
+    BreakLoop = 0x08,
+    ContinueLoop = 0x09,
 
     // Error handling
-    NewTryBlock,
-    EndTryBlock,
-    SetOperationStatus,
-    GetOperationStatus,
+    NewTryBlock = 0x0a,
+    EndTryBlock = 0x0b,
+    SetOperationStatus = 0x0c,
+    GetOperationStatus = 0x0d,
 
     // Arithmetic
-    Add,
-    Subtract,
-    Multiply,
-    Divide,
-    BinaryAdd,
-    BinarySubtract,
-    BinaryMultiply,
-    BinaryDivide,
+    Add = 0x0e,
+    Subtract = 0x0f,
+    Multiply = 0x10,
+    Divide = 0x11,
+    BinaryAdd = 0x12,
+    BinarySubtract = 0x13,
+    BinaryMultiply = 0x14,
+    BinaryDivide = 0x15,
 
     // Boolean operators
-    InPlaceBoolNot,
-    InPlaceBoolAnd,
-    InPlaceBoolOr,
+    InPlaceBoolNot = 0x16,
+    InPlaceBoolAnd = 0x17,
+    InPlaceBoolOr = 0x18,
 
-    BoolNot,
-    BoolAnd,
-    BoolOr,
+    BoolNot = 0x19,
+    BoolAnd = 0x1a,
+    BoolOr = 0x1b,
 
     // Generic comparison
-    Compare,
+    Compare = 0x1c,
 
     // New object constructors
-    NewInt,
-    NewUint,
-    NewBool,
-    NewDouble,
-    NewChar,
-    NewString,
-    NewPoint,
-    NewRect,
-    NewArray,
-    NewStringMap,
-    NewNull,
+    NewInt = 0x1d,
+    NewUint = 0x1e,
+    NewBool = 0x1f,
+    NewDouble = 0x20,
+    NewChar = 0x21,
+    NewString = 0x22,
+    NewPoint = 0x23,
+    NewRect = 0x24,
+    NewArray = 0x25,
+    NewStringMap = 0x26,
+    NewNull = 0x27,
 
     // Point and Rect methods
-    GetPointProperty,
-    GetRectProperty,
+    GetPointProperty = 0x28,
+    GetRectProperty = 0x29,
 
     // RemoteArray methods
-    RemoteArrayAppend,
-    RemoteArraySetAt,
-    RemoteArrayRemoveAt,
-    RemoteArrayGetAt,
-    RemoteArraySize,
+    RemoteArrayAppend = 0x2a,
+    RemoteArraySetAt = 0x2b,
+    RemoteArrayRemoveAt = 0x2c,
+    RemoteArrayGetAt = 0x2d,
+    RemoteArraySize = 0x2e,
 
     // RemoteStringMap methods
-    RemoteStringMapInsert,
-    RemoteStringMapRemove,
-    RemoteStringMapHasKey,
-    RemoteStringMapLookup,
-    RemoteStringMapSize,
+    RemoteStringMapInsert = 0x2f,
+    RemoteStringMapRemove = 0x30,
+    RemoteStringMapHasKey = 0x31,
+    RemoteStringMapLookup = 0x32,
+    RemoteStringMapSize = 0x33,
 
     // RemoteString methods
-    RemoteStringGetAt,
-    RemoteStringSubstr,
-    RemoteStringConcat,
-    RemoteStringSize,
+    RemoteStringGetAt = 0x34,
+    RemoteStringSubstr = 0x35,
+    RemoteStringConcat = 0x36,
+    RemoteStringSize = 0x37,
 
     // UIA element methods
-    GetPropertyValue,
-    Navigate,
+    GetPropertyValue = 0x38,
+    Navigate = 0x39,
 
     // Type interrogation methods
-    IsNull,
-    IsNotSupported,
-    IsMixedAttribute,
-    IsBool,
-    IsInt,
-    IsUint,
-    IsDouble,
-    IsChar,
-    IsString,
-    IsPoint,
-    IsRect,
-    IsArray,
-    IsStringMap,
-    IsElement,
+    IsNull = 0x3a,
+    IsNotSupported = 0x3b,
+    IsMixedAttribute = 0x3c,
+    IsBool = 0x3d,
+    IsInt = 0x3e,
+    IsUint = 0x3f,
+    IsDouble = 0x40,
+    IsChar = 0x41,
+    IsString = 0x42,
+    IsPoint = 0x43,
+    IsRect = 0x44,
+    IsArray = 0x45,
+    IsStringMap = 0x46,
+    IsElement = 0x47,
+
+    // GUID support
+    NewGuid = 0x48,
+    IsGuid = 0x49,
+    LookupId = 0x4a,
+    LookupGuid = 0x4b,
 
     // UIA pattern getters and pattern methods
 #include "RemoteOperationInstructionEnumValues.g.h"
@@ -215,6 +221,10 @@ constexpr std::array c_supportedInstructions =
     InstructionType::IsArray,
     InstructionType::IsStringMap,
     InstructionType::IsElement,
+    InstructionType::NewGuid,
+    InstructionType::IsGuid,
+    InstructionType::LookupId,
+    InstructionType::LookupGuid,
 
     // Auto-generated UIA pattern getters and pattern methods
 #include "RemoteOperationInstructionEnumValuesArray.g.h"
@@ -819,6 +829,39 @@ struct IsElement : GetterBase
     constexpr static InstructionType type = InstructionType::IsElement;
 };
 
+struct NewGuid
+{
+    constexpr static InstructionType type = InstructionType::NewGuid;
+
+    OperandId resultId;
+    GUID initialValue;
+};
+
+struct IsGuid : GetterBase
+{
+    constexpr static InstructionType type = InstructionType::IsGuid;
+};
+
+struct LookupId
+{
+    constexpr static InstructionType type = InstructionType::LookupId;
+
+    OperandId resultId;
+
+    OperandId guidId;
+    AutomationIdentifierType idType;
+};
+
+struct LookupGuid
+{
+    constexpr static InstructionType type = InstructionType::LookupGuid;
+
+    OperandId resultId;
+
+    OperandId intIdId;
+    AutomationIdentifierType idType;
+};
+
 #include "RemoteOperationInstructions.g.h"
 
 using Instruction = std::variant<
@@ -921,7 +964,11 @@ using Instruction = std::variant<
     IsRect,
     IsArray,
     IsStringMap,
-    IsElement
+    IsElement,
+    NewGuid,
+    IsGuid,
+    LookupId,
+    LookupGuid
 
 #include "RemoteOperationInstructionsVariantParams.g.h"
     >;

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -323,6 +323,35 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return result;
     }
 
+    // AutomationRemoteGuid
+
+    AutomationRemoteGuid::AutomationRemoteGuid(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
+        : base_type(operandId, parent)
+    {
+    }
+
+    winrt::AutomationRemoteAnnotationType AutomationRemoteGuid::LookupAnnotationType()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::LookupId{
+            resultId,
+            m_operandId,
+            AutomationIdentifierType_Annotation
+        });
+        return Make<AutomationRemoteAnnotationType>(resultId);
+    }
+
+    winrt::AutomationRemotePropertyId AutomationRemoteGuid::LookupPropertyId()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::LookupId{
+            resultId,
+            m_operandId,
+            AutomationIdentifierType_Property
+        });
+        return Make<AutomationRemotePropertyId>(resultId);
+    }
+
     // AutomationRemoteArray
 
     AutomationRemoteArray::AutomationRemoteArray(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
@@ -668,6 +697,21 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     winrt::AutomationRemoteRect AutomationRemoteAnyObject::AsRect()
     {
         return As<AutomationRemoteRect>();
+    }
+
+    winrt::AutomationRemoteBool AutomationRemoteAnyObject::IsGuid()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::IsGuid{
+            resultId,
+            m_operandId
+        });
+        return Make<AutomationRemoteBool>(resultId);
+    }
+
+    winrt::AutomationRemoteGuid AutomationRemoteAnyObject::AsGuid()
+    {
+        return As<AutomationRemoteGuid>();
     }
 
     winrt::AutomationRemoteBool AutomationRemoteAnyObject::IsArray()

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.g.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.g.h
@@ -105,6 +105,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         void Set(const class_type& rhs);
         winrt::AutomationRemoteBool IsEqual(const class_type& rhs);
         winrt::AutomationRemoteBool IsNotEqual(const class_type& rhs);
+        winrt::AutomationRemoteGuid LookupGuid();
     };
 
     class AutomationRemoteBulletStyle : public AutomationRemoteBulletStyleT<AutomationRemoteBulletStyle, AutomationRemoteObject>
@@ -249,6 +250,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         void Set(const class_type& rhs);
         winrt::AutomationRemoteBool IsEqual(const class_type& rhs);
         winrt::AutomationRemoteBool IsNotEqual(const class_type& rhs);
+        winrt::AutomationRemoteGuid LookupGuid();
     };
 
     class AutomationRemoteRowOrColumnMajor : public AutomationRemoteRowOrColumnMajorT<AutomationRemoteRowOrColumnMajor, AutomationRemoteObject>

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -12,6 +12,7 @@
 #include "AutomationRemoteString.g.h"
 #include "AutomationRemotePoint.g.h"
 #include "AutomationRemoteRect.g.h"
+#include "AutomationRemoteGuid.g.h"
 #include "AutomationRemoteArray.g.h"
 #include "AutomationRemoteStringMap.g.h"
 #include "AutomationRemoteElement.g.h"
@@ -448,6 +449,30 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteDouble GetY();
     };
 
+    class AutomationRemoteGuid : public AutomationRemoteGuidT<AutomationRemoteGuid, AutomationRemoteObject>
+    {
+    public:
+        AutomationRemoteGuid(bytecode::OperandId operandId, AutomationRemoteOperation& parent);
+
+        void Set(const class_type& rhs)
+        {
+            AutomationRemoteObject::Set<AutomationRemoteGuid>(rhs);
+        }
+
+        auto IsEqual(const class_type& rhs)
+        {
+            return AutomationRemoteObject::IsEqual<AutomationRemoteGuid>(rhs);
+        }
+
+        auto IsNotEqual(const class_type& rhs)
+        {
+            return AutomationRemoteObject::IsNotEqual<AutomationRemoteGuid>(rhs);
+        }
+
+        winrt::AutomationRemoteAnnotationType LookupAnnotationType();
+        winrt::AutomationRemotePropertyId LookupPropertyId();
+    };
+
     class AutomationRemoteArray : public AutomationRemoteArrayT<AutomationRemoteArray, AutomationRemoteObject>
     {
     public:
@@ -531,6 +556,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemotePoint AsPoint();
         winrt::AutomationRemoteBool IsRect();
         winrt::AutomationRemoteRect AsRect();
+        winrt::AutomationRemoteBool IsGuid();
+        winrt::AutomationRemoteGuid AsGuid();
         winrt::AutomationRemoteBool IsArray();
         winrt::AutomationRemoteArray AsArray();
         winrt::AutomationRemoteBool IsStringMap();


### PR DESCRIPTION
The platform implementation of remote operations now supports a GUID operand type and instructions for working with this type. These additions are necessary when working with UIA extensions such as custom properties and the upcoming support for custom annotations. This PR exposes the new GUID type and related instructions in the high-level WinRT builder API and adds test coverage at that level.