### PR TITLE
Enable Azure Pipelines build validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://dev.azure.com/ms/Microsoft-UI-UIAutomation/_apis/build/status/Microsoft-UI-UIAutomation%20Desktop%20CI?branchName=main)](https://dev.azure.com/ms/Microsoft-UI-UIAutomation/_build/latest?definitionId=378&branchName=main)
 
 # Windows UIAutomation platform utility libraries
 

--- a/build/Install-WindowsSdkISO.ps1
+++ b/build/Install-WindowsSdkISO.ps1
@@ -1,0 +1,334 @@
+[CmdletBinding()]
+param([Parameter(Mandatory=$true, Position=0)]
+      [string]$buildNumber)
+
+# Ensure the error action preference is set to the default for PowerShell3, 'Stop'
+$ErrorActionPreference = 'Stop'
+
+# Constants
+$WindowsSDKOptions = @("OptionId.UWPCpp", "OptionId.UWPManaged", "OptionId.DesktopCPPx86", "OptionId.DesktopCPPx64")
+$WindowsSDKRegPath = "HKLM:\Software\Microsoft\Windows Kits\Installed Roots"
+$WindowsSDKRegRootKey = "KitsRoot10"
+$WindowsSDKVersion = "10.0.$buildNumber.0"
+$WindowsSDKInstalledRegPath = "$WindowsSDKRegPath\$WindowsSDKVersion\Installed Options"
+$StrongNameRegPath = "HKLM:\SOFTWARE\Microsoft\StrongName\Verification"
+$PublicKeyTokens = @("31bf3856ad364e35")
+
+if ($buildNumber -notmatch "^\d{5,}$")
+{
+    Write-Host "ERROR: '$buildNumber' doesn't look like a windows build number"
+    Write-Host
+    Exit 1
+}
+
+function Download-File
+{
+    param ([string] $outDir,
+           [string] $downloadUrl,
+           [string] $downloadName)
+
+    $downloadPath = Join-Path $outDir "$downloadName.download"
+    $downloadDest = Join-Path $outDir $downloadName
+    $downloadDestTemp = Join-Path $outDir "$downloadName.tmp"
+
+    Write-Host -NoNewline "Downloading $downloadName..."
+
+    try
+    {
+        $webclient = new-object System.Net.WebClient
+        $webclient.DownloadFile($downloadUrl, $downloadPath)
+    }
+    catch [System.Net.WebException]
+    {
+        Write-Host
+        Write-Warning "Failed to fetch updated file from $downloadUrl"
+        if (!(Test-Path $downloadDest))
+        {
+            throw "$downloadName was not found at $downloadDest"
+        }
+        else
+        {
+            Write-Warning "$downloadName may be out of date"
+        }
+    }
+
+    Unblock-File $downloadPath
+
+    $downloadDestTemp = $downloadPath;
+
+    # Delete and rename to final dest
+    if (Test-Path -PathType Container $downloadDest)
+    {
+        [System.IO.Directory]::Delete($downloadDest, $true)
+    }
+
+    Move-Item -Force $downloadDestTemp $downloadDest
+    Write-Host "Done"
+
+    return $downloadDest
+}
+
+function Get-ISODriveLetter
+{
+    param ([string] $isoPath)
+
+    $diskImage = Get-DiskImage -ImagePath $isoPath
+    if ($diskImage)
+    {
+        $volume = Get-Volume -DiskImage $diskImage
+
+        if ($volume)
+        {
+            $driveLetter = $volume.DriveLetter
+            if ($driveLetter)
+            {
+                $driveLetter += ":"
+                return $driveLetter
+            }
+        }
+    }
+
+    return $null
+}
+
+function Mount-ISO
+{
+    param ([string] $isoPath)
+
+    # Check if image is already mounted
+    $isoDrive = Get-ISODriveLetter $isoPath
+
+    if (!$isoDrive)
+    {
+        Mount-DiskImage -ImagePath $isoPath -StorageType ISO | Out-Null
+    }
+
+    $isoDrive = Get-ISODriveLetter $isoPath
+    Write-Verbose "$isoPath mounted to ${isoDrive}:"
+}
+
+function Dismount-ISO
+{
+    param ([string] $isoPath)
+
+    $isoDrive = (Get-DiskImage -ImagePath $isoPath | Get-Volume).DriveLetter
+
+    if ($isoDrive)
+    {
+        Write-Verbose "$isoPath dismounted"
+        Dismount-DiskImage -ImagePath $isoPath | Out-Null
+    }
+}
+
+function Disable-StrongName
+{
+    param ([string] $publicKeyToken = "*")
+
+    reg ADD "HKLM\SOFTWARE\Microsoft\StrongName\Verification\*,$publicKeyToken" /f | Out-Null
+    if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64")
+    {
+        reg ADD "HKLM\SOFTWARE\Wow6432Node\Microsoft\StrongName\Verification\*,$publicKeyToken" /f | Out-Null
+    }
+}
+
+function Test-Admin
+{
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal $identity
+    $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Test-RegistryPathAndValue
+{
+    param (
+        [parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $path,
+        [parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $value)
+
+    try
+    {
+        if (Test-Path $path)
+        {
+            Get-ItemProperty -Path $path | Select-Object -ExpandProperty $value -ErrorAction Stop | Out-Null
+            return $true
+        }
+    }
+    catch
+    {
+    }
+
+    return $false
+}
+
+function Test-InstallWindowsSDK
+{
+    $retval = $true
+
+    if (Test-RegistryPathAndValue -Path $WindowsSDKRegPath -Value $WindowsSDKRegRootKey)
+    {
+        $correctWindowsSdkIsInstalled = $false
+        
+        # A Windows SDK is installed
+        # Is an SDK of our version installed with the options we need?
+        foreach ($windowsSDKOption in $WindowsSDKOptions)
+        {
+            $correctWindowsSdkIsInstalled = $correctWindowsSdkIsInstalled -and (Test-RegistryPathAndValue -Path $WindowsSDKInstalledRegPath -Value "$windowsSDKOption")
+        }
+
+        if ($correctWindowsSdkIsInstalled)
+        {
+            # It appears we have what we need. Double check the disk
+            $sdkRoot = Get-ItemProperty -Path $WindowsSDKRegPath | Select-Object -ExpandProperty $WindowsSDKRegRootKey
+            if ($sdkRoot)
+            {
+                if (Test-Path $sdkRoot)
+                {
+                    $refPath = Join-Path $sdkRoot "References\$WindowsSDKVersion"
+                    if (Test-Path $refPath)
+                    {
+                        $umdPath = Join-Path $sdkRoot "UnionMetadata\$WindowsSDKVersion"
+                        if (Test-Path $umdPath)
+                        {
+                            # Pretty sure we have what we need
+                            $retval = $false
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return $retval
+}
+
+function Test-InstallStrongNameHijack
+{
+    foreach($publicKeyToken in $PublicKeyTokens)
+    {
+        $key = "$StrongNameRegPath\*,$publicKeyToken"
+        if (!(Test-Path $key))
+        {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+Write-Host -NoNewline "Checking for installed Windows SDK $WindowsSDKVersion..."
+$InstallWindowsSDK = Test-InstallWindowsSDK
+if ($InstallWindowsSDK)
+{
+    Write-Host "Installation required"
+}
+else
+{
+    Write-Host "INSTALLED"
+}
+
+$StrongNameHijack = Test-InstallStrongNameHijack
+Write-Host -NoNewline "Checking if StrongName bypass required..."
+
+if ($StrongNameHijack)
+{
+    Write-Host "REQUIRED"
+}
+else
+{
+    Write-Host "Done"
+}
+
+if ($StrongNameHijack -or $InstallWindowsSDK)
+{
+    if (!(Test-Admin))
+    {
+        Write-Host
+        throw "ERROR: Elevation required"
+    }
+}
+
+if ($InstallWindowsSDK)
+{
+    # Static(ish) link for Windows SDK
+    # Note: there is a delay from Windows SDK announcements to availability via the static link
+    $uri = "https://software-download.microsoft.com/download/sg/Windows_InsiderPreview_SDK_en-us_$($buildNumber)_1.iso";
+
+    if ($env:TEMP -eq $null)
+    {
+        $env:TEMP = Join-Path $env:SystemDrive 'temp'
+    }
+
+    $winsdkTempDir = Join-Path $env:TEMP "WindowsSDK"
+
+    if (![System.IO.Directory]::Exists($winsdkTempDir))
+    {
+        [void][System.IO.Directory]::CreateDirectory($winsdkTempDir)
+    }
+
+    $file = "winsdk_$buildNumber.iso"
+
+    if (!(Test-Path $winsdkTempDir\$file))
+    {
+        Write-Verbose "Getting WinSDK from $uri"
+        $downloadFile = Download-File $winsdkTempDir $uri $file
+        Write-Verbose "File is at $downloadFile"
+    }
+    else
+    {
+        Write-Verbose "iso already there"
+        $downloadFile = "$winsdkTempDir\$file"
+    }
+    $downloadFileItem = Get-Item $downloadFile
+    
+    # Check to make sure the file is at least 10 MB.
+    if ($downloadFileItem.Length -lt 10*1024*1024)
+    {
+        Write-Host
+        Write-Host "ERROR: Downloaded file doesn't look large enough to be an ISO. The requested version may not be on microsoft.com yet."
+        Write-Host
+        Exit 1
+    }
+
+    # TODO Check if zip, exe, iso, etc.
+    try
+    {
+        Write-Host -NoNewline "Mounting ISO $file..."
+        Mount-ISO $downloadFile
+        Write-Host "Done"
+
+        $isoDrive = Get-ISODriveLetter $downloadFile
+
+        if (Test-Path $isoDrive)
+        {
+            $setupPath = Join-Path "$isoDrive" "WinSDKSetup.exe"
+            Write-Host -NoNewLine "Installing WinSDK..."
+            Start-Process -Wait $setupPath "/features $($WindowsSDKOptions -join " ") /q"
+            Write-Host "Done"
+        }
+        else
+        {
+            throw "Could not find mounted ISO at ${isoDrive}"
+        }
+    }
+    finally
+    {
+        Write-Host -NoNewline "Dismounting ISO $file..."
+        #Dismount-ISO $downloadFile
+        Write-Host "Done"
+    }
+}
+
+if ($StrongNameHijack)
+{
+    Write-Host -NoNewline "Disabling StrongName for Windows SDK..."
+
+    foreach($key in $PublicKeyTokens)
+    {
+        Disable-StrongName $key
+    }
+
+    Write-Host "Done"
+}

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.vcxproj
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.vcxproj
@@ -123,7 +123,7 @@
       <Inputs>$(IntDir)$(ProjectName).winmd</Inputs>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd"</Command>
+      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy winmd to output directory</Message>
@@ -166,7 +166,7 @@
       <Inputs>$(IntDir)$(ProjectName).winmd</Inputs>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd"</Command>
+      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy winmd to output directory</Message>
@@ -213,7 +213,7 @@
       <Inputs>$(IntDir)$(ProjectName).winmd</Inputs>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd"</Command>
+      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy winmd to output directory</Message>
@@ -260,7 +260,7 @@
       <Inputs>$(IntDir)$(ProjectName).winmd</Inputs>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd"</Command>
+      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy winmd to output directory</Message>

--- a/src/UIAutomation/SharpConsoleAppDemo/SharpConsoleAppDemo.csproj
+++ b/src/UIAutomation/SharpConsoleAppDemo/SharpConsoleAppDemo.csproj
@@ -48,7 +48,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Windows">
-      <HintPath>$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd</HintPath>
+      <HintPath>..\Microsoft.UI.UIAutomation\Generated Files\winmd\Windows.winmd</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/UIAutomation/UIAutomation.sln
+++ b/src/UIAutomation/UIAutomation.sln
@@ -11,6 +11,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FunctionalTests", "Function
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpConsoleAppDemo", "SharpConsoleAppDemo\SharpConsoleAppDemo.csproj", "{E7DA5D8D-01C1-401E-8613-352A19E12538}"
+	ProjectSection(ProjectDependencies) = postProject
+		{7D645239-F96E-4FBE-BAA4-B92838B9D361} = {7D645239-F96E-4FBE-BAA4-B92838B9D361}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UiaOperationAbstraction", "UiaOperationAbstraction\UiaOperationAbstraction.vcxproj", "{A5682ADB-8C0C-4CFD-AED9-2E979751FDCC}"
 	ProjectSection(ProjectDependencies) = postProject


### PR DESCRIPTION
In order to enable automatic CI in Azure Pipelines, we need to ensure that the appropriate version of the Insider Preview SDK is installed on the build machine. This is achieved by the new `Install-WindowsSdkISO` script. This is the same approach that other projects use, for instance `microsoft-ui-xaml`.

The PR also fixes an issue with build order/dependency for the C# demo app: it now explicitly depends on the `Microsoft.UI.UIAutomation` project (since it needs the metadata produced by this step). The `Windows.winmd` file that was referenced when `Microsoft.UI.UIAutomation.winmd` itself was built is copied to the same output directory just to make sure that all projects wind up referencing all the same metadata.

Closes #7 