### PR TITLE
Add support for accessing UIA rectangle dimensions to `UiaRect`

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -368,7 +368,7 @@ namespace UiaOperationAbstractionTests
                 std::tie(x, y, width, height) = std::tuple(boundingRectangleX, boundingRectangleY, boundingRectangleWidth, boundingRectangleHeight);
             }
 
-            // Compare fields of the element's bounding rectangle against the individually-fetched values.
+            // Compare fields of the element's bounding rectangle against the just-fetched values.
             {
                 Assert::AreEqual(static_cast<double>(boundingRect.X), x);
                 Assert::AreEqual(static_cast<double>(boundingRect.Y), y);

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -1606,6 +1606,60 @@ namespace UiaOperationAbstraction
             (lhsLocalRect.Width != rhsLocalRect.Width) ||
             (lhsLocalRect.X != rhsLocalRect.X) ||
             (lhsLocalRect.Y != rhsLocalRect.Y);
+    }    UiaDouble UiaRect::GetHeight() const
+    {
+        if (ShouldUseRemoteApi())
+        {
+            auto remoteValue = std::get_if<RemoteType>(&m_member);
+            if (remoteValue)
+            {
+                return remoteValue->GetHeight();
+            }
+        }
+
+        return static_cast<double>(std::get<LocalType>(m_member).Height);
+    }
+
+    UiaDouble UiaRect::GetWidth() const
+    {
+        if (ShouldUseRemoteApi())
+        {
+            auto remoteValue = std::get_if<RemoteType>(&m_member);
+            if (remoteValue)
+            {
+                return remoteValue->GetWidth();
+            }
+        }
+
+        return static_cast<double>(std::get<LocalType>(m_member).Width);
+    }
+
+    UiaDouble UiaRect::GetX() const
+    {
+        if (ShouldUseRemoteApi())
+        {
+            auto remoteValue = std::get_if<RemoteType>(&m_member);
+            if (remoteValue)
+            {
+                return remoteValue->GetX();
+            }
+        }
+
+        return static_cast<double>(std::get<LocalType>(m_member).X);
+    }
+
+    UiaDouble UiaRect::GetY() const
+    {
+        if (ShouldUseRemoteApi())
+        {
+            auto remoteValue = std::get_if<RemoteType>(&m_member);
+            if (remoteValue)
+            {
+                return remoteValue->GetY();
+            }
+        }
+
+        return static_cast<double>(std::get<LocalType>(m_member).Y);
     }
 
     UiaHwnd::UiaHwnd(UIA_HWND hwnd):

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -1606,7 +1606,9 @@ namespace UiaOperationAbstraction
             (lhsLocalRect.Width != rhsLocalRect.Width) ||
             (lhsLocalRect.X != rhsLocalRect.X) ||
             (lhsLocalRect.Y != rhsLocalRect.Y);
-    }    UiaDouble UiaRect::GetHeight() const
+    }
+    
+    UiaDouble UiaRect::GetHeight() const
     {
         if (ShouldUseRemoteApi())
         {

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1041,6 +1041,12 @@ namespace UiaOperationAbstraction
 
         UiaBool operator==(const UiaRect& rhs) const;
         UiaBool operator!=(const UiaRect& rhs) const;
+
+        UiaDouble GetHeight() const;
+        UiaDouble GetWidth() const;
+        UiaDouble GetX() const;
+        UiaDouble GetY() const;
+
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
 


### PR DESCRIPTION
`winrt::Microsoft::UI::UIAutomation::AutomationRemoteRect` has full support for reading `X`, `Y`, `Width` and `Height` of rectangle properties and attributes. However, `UiaRect` defined by the UIA operation abstraction library does not give access to the these qualities of rectangles.

This change adds the missing support for the rectangle members/qualities to `UiaRect`.

The support allows implementing heuristics around rectangles and the areas they cover (such as Win32's `IsRectEmpty`) through the abstraction library types and operations.

Resolves #15 