### PR TITLE
AutomationRemoteArray: Add equality comparison methods

### DIFF
--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -128,6 +128,8 @@ namespace Microsoft.UI.UIAutomation
     runtimeclass AutomationRemoteArray : AutomationRemoteObject
     {
         void Set(AutomationRemoteArray rhs);
+        AutomationRemoteBool IsEqual(AutomationRemoteArray rhs);
+        AutomationRemoteBool IsNotEqual(AutomationRemoteArray rhs);
 
         void Append(AutomationRemoteObject obj);
         void SetAt(AutomationRemoteUint index, AutomationRemoteObject obj);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -484,6 +484,16 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
             AutomationRemoteObject::Set<AutomationRemoteArray>(rhs);
         }
 
+        auto IsEqual(const class_type& rhs)
+        {
+            return AutomationRemoteObject::IsEqual<AutomationRemoteArray>(rhs);
+        }
+
+        auto IsNotEqual(const class_type& rhs)
+        {
+            return AutomationRemoteObject::IsNotEqual<AutomationRemoteArray>(rhs);
+        }
+
         void Append(winrt::AutomationRemoteObject obj);
         void SetAt(winrt::AutomationRemoteUint index, winrt::AutomationRemoteObject obj);
         winrt::AutomationRemoteAnyObject RemoveAt(winrt::AutomationRemoteUint index);


### PR DESCRIPTION
Remote arrays can be compared for equality in the underlying Remote
Operations VM. This PR exposes this functionality via the builder methods.

Notably, this allows Runtime Ids to be compared more efficiently than before.

(Previously, it was _possible_, but the Remote Op itself needed to implement
element-by-element comparison, which would count against the instruction
limit, waste time at runtime, as well as was more complex than it really should
be for an important and relatively common thing.)