### PR TITLE
UiaHwnd: Add implementation of conversion operator to UIA_HWND

### DIFF
--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -1680,6 +1680,11 @@ namespace UiaOperationAbstraction
     {
     }
 
+    UiaHwnd::operator UIA_HWND() const
+    {
+        return std::get<UIA_HWND>(m_member);
+    }
+
     UiaBool UiaHwnd::operator==(const UiaHwnd& rhs) const
     {
         return BinaryOperator<UiaHwnd, Equal>(this->m_member, rhs.m_member);


### PR DESCRIPTION
The UiaHwnd class has the conversion operator declared in the header file, which aims to be used to get to the local type from the abstraction type. But the implementation is not in place, so the client of operation abstraction such as Narrator will get the linking error while building DLLs since the implementation is missing in the static lib.

This change adds the simple implementation here to get the local type.