### PR TITLE
Add array comparison in the abstraction wrapper

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -429,5 +429,55 @@ namespace UiaOperationAbstractionTests
         {
             RectDimensions(true /* useRemoteOperations */);
         }
+
+        void ArrayEqualityComparisonTest(const bool useRemoteOperations)
+        {
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+            auto calc = WaitForElementFocus(L"Display is 0");
+
+            auto guard = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            auto scope = UiaOperationScope::StartNew();
+
+            UiaElement element = calc;
+            UiaArray<UiaInt> runtimeIdFirst = element.GetRuntimeId();
+            UiaArray<UiaInt> runtimeIdSecond = element.GetRuntimeId();
+
+            UiaBool sameElementEqualResult{ false };
+            sameElementEqualResult = (runtimeIdFirst == runtimeIdSecond);
+            UiaBool sameElementNonEqualResult{ true };
+            sameElementNonEqualResult = (runtimeIdFirst != runtimeIdSecond);
+
+            UiaElement parent = element.GetParentElement();
+            UiaArray<UiaInt> runtimeIdParent = parent.GetRuntimeId();
+
+            UiaBool diffElementEqualResult{ true };
+            diffElementEqualResult = (runtimeIdFirst == runtimeIdParent);
+            UiaBool diffElementNonEqualResult{ false };
+            diffElementNonEqualResult = (runtimeIdFirst != runtimeIdParent);
+
+            scope.BindResult(sameElementEqualResult);
+            scope.BindResult(sameElementNonEqualResult);
+            scope.BindResult(diffElementEqualResult);
+            scope.BindResult(diffElementNonEqualResult);
+
+            scope.Resolve();
+
+            Assert::IsTrue(sameElementEqualResult);
+            Assert::IsFalse(sameElementNonEqualResult);
+            Assert::IsFalse(diffElementEqualResult);
+            Assert::IsTrue(diffElementNonEqualResult);
+        }
+
+        TEST_METHOD(ArrayEqualityComparisonLocalTest)
+        {
+            ArrayEqualityComparisonTest(false);
+        }
+
+        TEST_METHOD(ArrayEqualityComparisonRemoteTest)
+        {
+            ArrayEqualityComparisonTest(true);
+        }
     };
 }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1186,6 +1186,42 @@ namespace UiaOperationAbstraction
             return *std::get<LocalType>(m_member);
         }
 
+        UiaBool operator==(const UiaArray& rhs) const
+        {
+            if (ShouldUseRemoteApi())
+            {
+                auto mutableThis = *this;
+                mutableThis.ToRemote();
+
+                auto mutableRhs = rhs;
+                mutableRhs.ToRemote();
+                return std::get<RemoteType>(mutableThis.m_member).IsEqual(std::get<RemoteType>(mutableRhs.m_member));
+            }
+
+            auto localVector = std::get<LocalType>(m_member);
+            auto localRhsVector = std::get<LocalType>(rhs.m_member);
+
+            if (localVector->size() != localRhsVector->size())
+            {
+                return false;
+            }
+
+            for (size_t i = 0; i < localVector->size(); ++i)
+            {
+                if (localVector->at(i) != localRhsVector->at(i))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        UiaBool operator!=(const UiaArray& rhs) const
+        {
+            return !(*this == rhs);
+        }
+
         void ToRemote()
         {
             auto delegator = UiaOperationScope::GetCurrentDelegator();

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1114,6 +1114,34 @@ namespace UiaOperationAbstraction
         void PopulateCacheHelper(
             const winrt::Microsoft::UI::UIAutomation::AutomationRemoteArray& elements,
             const winrt::Microsoft::UI::UIAutomation::AutomationRemoteCacheRequest& cacheRequest);
+
+        template<class T>
+        constexpr bool IsArrayElementEqual(T lhs, T rhs)
+        {
+            if constexpr (std::is_same_v<T, bool> ||
+                std::is_same_v<T, int> ||
+                std::is_same_v<T, unsigned int> ||
+                std::is_same_v<T, double>)
+            {
+                return lhs == rhs;
+            }
+            else if constexpr (std::is_same_v<T, wil::shared_bstr>)
+            {
+                return (UiaString(lhs) == UiaString(rhs));
+            }
+            else if constexpr (std::is_same_v<T, winrt::Windows::Foundation::Rect>)
+            {
+                return (UiaRect(lhs) == UiaRect(rhs));
+            }
+            else if constexpr (std::is_same_v<T, winrt::Windows::Foundation::Point>)
+            {
+                return (UiaPoint(lhs) == UiaPoint(rhs));
+            }
+            else
+            {
+                THROW_HR(E_UNEXPECTED);
+            }
+        }
     } // namespace impl
 
     template <class ItemWrapperType>
@@ -1208,7 +1236,7 @@ namespace UiaOperationAbstraction
 
             for (size_t i = 0; i < localVector->size(); ++i)
             {
-                if (localVector->at(i) != localRhsVector->at(i))
+                if (!impl::IsArrayElementEqual((*localVector)[i], (*localRhsVector)[i]))
                 {
                     return false;
                 }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1139,7 +1139,7 @@ namespace UiaOperationAbstraction
             }
             else
             {
-                THROW_HR(E_UNEXPECTED);
+                static_assert(always_false<T>::value, "Unexpected array element comparison type.");
             }
         }
     } // namespace impl


### PR DESCRIPTION
The ability of achieving array comparison was recently added in remote operation implementation. This PR wires up array comparison in the abstraction wrapper so that client such as Narrator could use it in a convenient way.