### PR TITLE
Add support for `IUIAutomationElement::BuildUpdatedCache` to the UIA operation abstraction library

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -480,7 +480,7 @@ namespace UiaOperationAbstractionTests
             ArrayEqualityComparisonTest(true);
         }
 
-        void BuildUpdatedCache(bool useRemoteOperations)
+        void GetUpdatedCacheElement(bool useRemoteOperations)
         {
             // Initialize the test application.
             ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
@@ -513,8 +513,8 @@ namespace UiaOperationAbstractionTests
                 cacheRequestWithControlType.AddProperty(UIA_ControlTypePropertyId);
 
                 // Rebuild the imported element with the filled cache requests.
-                auto remoteElementWithName = displayElement.BuildUpdatedCache(cacheRequestWithName);
-                auto remoteElementWithControlType = displayElement.BuildUpdatedCache(cacheRequestWithControlType);
+                auto remoteElementWithName = displayElement.GetUpdatedCacheElement(cacheRequestWithName);
+                auto remoteElementWithControlType = displayElement.GetUpdatedCacheElement(cacheRequestWithControlType);
                 operationScope.BindResult(remoteElementWithName);
                 operationScope.BindResult(remoteElementWithControlType);
                 operationScope.Resolve();
@@ -548,14 +548,14 @@ namespace UiaOperationAbstractionTests
             }
         }
 
-        TEST_METHOD(BuildUpdatedCacheLocal)
+        TEST_METHOD(GetUpdatedCacheElementLocal)
         {
-            BuildUpdatedCache(false /* useRemoteOperations */);
+            GetUpdatedCacheElement(false /* useRemoteOperations */);
         }
 
-        TEST_METHOD(BuildUpdatedCacheRemote)
+        TEST_METHOD(GetUpdatedCacheElementRemote)
         {
-            BuildUpdatedCache(true /* useRemoteOperations */);
+            GetUpdatedCacheElement(true /* useRemoteOperations */);
         }
     };
 }

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -479,5 +479,83 @@ namespace UiaOperationAbstractionTests
         {
             ArrayEqualityComparisonTest(true);
         }
+
+        void BuildUpdatedCache(bool useRemoteOperations)
+        {
+            // Initialize the test application.
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+
+            // Set focus to the display element.
+            auto focusedElement = WaitForElementFocus(L"Display is 0");
+
+            // Initialize the UIA Remote Operation abstraction.
+            const auto cleanup = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            // Rebuild the cache of the focused element using two different cache requests with distinct
+            // properties in them to test that the rebuilt elements are different and contain requested
+            // and expected properties in their cache.
+            winrt::com_ptr<IUIAutomationElement> elementWithName;
+            winrt::com_ptr<IUIAutomationElement> elementWithControlType;
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Import the element to the remote operation.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                // Create two distinct cache requests to return two objects representing the same element
+                // but with different cached properties.
+                UiaOperationAbstraction::UiaCacheRequest cacheRequestWithName;
+                cacheRequestWithName.AddProperty(UIA_NamePropertyId);
+
+                UiaOperationAbstraction::UiaCacheRequest cacheRequestWithControlType;
+                cacheRequestWithControlType.AddProperty(UIA_ControlTypePropertyId);
+
+                // Rebuild the imported element with the filled cache requests.
+                auto remoteElementWithName = displayElement.BuildUpdatedCache(cacheRequestWithName);
+                auto remoteElementWithControlType = displayElement.BuildUpdatedCache(cacheRequestWithControlType);
+                operationScope.BindResult(remoteElementWithName);
+                operationScope.BindResult(remoteElementWithControlType);
+                operationScope.Resolve();
+
+                elementWithName = remoteElementWithName;
+                elementWithControlType = remoteElementWithControlType;
+            }
+
+            // Test the first element to make sure its cached property values contain `Name` but not `ControlType`.
+            {
+                wil::unique_variant name;
+                const HRESULT nameHr = elementWithName->GetCachedPropertyValueEx(UIA_NamePropertyId, TRUE /* ignoreDefaultValue */, &name);
+
+                wil::unique_variant controlType;
+                const HRESULT controlTypeHr = elementWithName->GetCachedPropertyValueEx(UIA_ControlTypePropertyId, TRUE /* ignoreDefaultValue */, &controlType);
+
+                Assert::AreEqual(S_OK, nameHr);
+                Assert::AreEqual(E_INVALIDARG, controlTypeHr);
+            }
+
+            // Test the second element whose cache should contain `ControlType` but not `Name`.
+            {
+                wil::unique_variant name;
+                const HRESULT nameHr = elementWithControlType->GetCachedPropertyValueEx(UIA_NamePropertyId, TRUE /* ignoreDefaultValue */, &name);
+
+                wil::unique_variant controlType;
+                const HRESULT controlTypeHr = elementWithControlType->GetCachedPropertyValueEx(UIA_ControlTypePropertyId, TRUE /* ignoreDefaultValue */, &controlType);
+
+                Assert::AreEqual(E_INVALIDARG, nameHr);
+                Assert::AreEqual(S_OK, controlTypeHr);
+            }
+        }
+
+        TEST_METHOD(BuildUpdatedCacheLocal)
+        {
+            BuildUpdatedCache(false /* useRemoteOperations */);
+        }
+
+        TEST_METHOD(BuildUpdatedCacheRemote)
+        {
+            BuildUpdatedCache(true /* useRemoteOperations */);
+        }
     };
 }

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -185,6 +185,7 @@ namespace Microsoft.UI.UIAutomation
         [default_overload] AutomationRemoteAnyObject GetPropertyValue(AutomationRemotePropertyId propertyId);
         AutomationRemoteAnyObject GetPropertyValue(AutomationRemotePropertyId propertyId, AutomationRemoteBool ignoreDefaultValue);
 
+        AutomationRemoteElement BuildUpdatedCache(AutomationRemoteCacheRequest cacheRequest);
         AutomationRemoteElement GetParentElement();
         AutomationRemoteElement GetFirstChildElement();
         AutomationRemoteElement GetLastChildElement();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -185,7 +185,7 @@ namespace Microsoft.UI.UIAutomation
         [default_overload] AutomationRemoteAnyObject GetPropertyValue(AutomationRemotePropertyId propertyId);
         AutomationRemoteAnyObject GetPropertyValue(AutomationRemotePropertyId propertyId, AutomationRemoteBool ignoreDefaultValue);
 
-        AutomationRemoteElement BuildUpdatedCache(AutomationRemoteCacheRequest cacheRequest);
+        AutomationRemoteElement GetUpdatedCacheElement(AutomationRemoteCacheRequest cacheRequest);
         AutomationRemoteElement GetParentElement();
         AutomationRemoteElement GetFirstChildElement();
         AutomationRemoteElement GetLastChildElement();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -523,6 +523,14 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return result;
     }
 
+    winrt::AutomationRemoteElement AutomationRemoteElement::BuildUpdatedCache(const winrt::AutomationRemoteCacheRequest& cacheRequest)
+    {
+        auto result = m_parent->NewNull().AsElement();
+        result.Set(*this);
+        result.PopulateCache(cacheRequest);
+        return result;
+    }
+
     winrt::AutomationRemoteElement AutomationRemoteElement::Navigate(const winrt::AutomationRemoteInt& direction)
     {
         const auto resultId = m_parent->GetNextId();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -523,7 +523,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return result;
     }
 
-    winrt::AutomationRemoteElement AutomationRemoteElement::BuildUpdatedCache(const winrt::AutomationRemoteCacheRequest& cacheRequest)
+    winrt::AutomationRemoteElement AutomationRemoteElement::GetUpdatedCacheElement(const winrt::AutomationRemoteCacheRequest& cacheRequest)
     {
         auto result = m_parent->NewNull().AsElement();
         result.Set(*this);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -545,7 +545,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
             const winrt::AutomationRemotePropertyId& propertyId,
             const winrt::AutomationRemoteBool& ignoreDefaultValue);
 
-        winrt::AutomationRemoteElement BuildUpdatedCache(const winrt::AutomationRemoteCacheRequest& cacheRequest);
+        winrt::AutomationRemoteElement GetUpdatedCacheElement(const winrt::AutomationRemoteCacheRequest& cacheRequest);
         winrt::AutomationRemoteElement GetParentElement();
         winrt::AutomationRemoteElement GetFirstChildElement();
         winrt::AutomationRemoteElement GetLastChildElement();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -545,6 +545,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
             const winrt::AutomationRemotePropertyId& propertyId,
             const winrt::AutomationRemoteBool& ignoreDefaultValue);
 
+        winrt::AutomationRemoteElement BuildUpdatedCache(const winrt::AutomationRemoteCacheRequest& cacheRequest);
         winrt::AutomationRemoteElement GetParentElement();
         winrt::AutomationRemoteElement GetFirstChildElement();
         winrt::AutomationRemoteElement GetLastChildElement();

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
@@ -2068,6 +2068,8 @@
         UiaCustomNavigationPattern GetCustomNavigationPattern(bool useCachedApi);
         UiaSelectionPattern2 GetSelectionPattern2(bool useCachedApi);
 
+        UiaElement BuildUpdatedCache(UiaCacheRequest cacheRequest);
+
         UiaElement GetParentElement(std::optional<UiaCacheRequest> cacheRequest = std::nullopt);
         UiaElement GetFirstChildElement(std::optional<UiaCacheRequest> cacheRequest = std::nullopt);
         UiaElement GetLastChildElement(std::optional<UiaCacheRequest> cacheRequest = std::nullopt);

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
@@ -2068,7 +2068,7 @@
         UiaCustomNavigationPattern GetCustomNavigationPattern(bool useCachedApi);
         UiaSelectionPattern2 GetSelectionPattern2(bool useCachedApi);
 
-        UiaElement BuildUpdatedCache(UiaCacheRequest cacheRequest);
+        UiaElement GetUpdatedCacheElement(UiaCacheRequest cacheRequest);
 
         UiaElement GetParentElement(std::optional<UiaCacheRequest> cacheRequest = std::nullopt);
         UiaElement GetFirstChildElement(std::optional<UiaCacheRequest> cacheRequest = std::nullopt);

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
@@ -6982,6 +6982,23 @@
         return localPattern;
     }
 
+    UiaElement UiaElement::BuildUpdatedCache(UiaCacheRequest cacheRequest)
+    {
+        auto delegator = UiaOperationScope::GetCurrentDelegator();
+        if (delegator && delegator->GetUseRemoteApi())
+        {
+            ToRemote();
+            return std::get<AutomationRemoteElement>(m_member).BuildUpdatedCache(cacheRequest);
+        }
+
+        const auto& localElement = std::get<winrt::com_ptr<IUIAutomationElement>>(m_member);
+        winrt::com_ptr<IUIAutomationElement> localResult;
+        winrt::check_hresult(localElement->BuildUpdatedCache(
+            (*cacheRequest).get(),
+            localResult.put()));
+        return localResult;
+    }
+
     UiaElement UiaElement::GetParentElement(std::optional<UiaCacheRequest> cacheRequest /* = std::nullopt */)
     {
         auto delegator = UiaOperationScope::GetCurrentDelegator();

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
@@ -6982,13 +6982,13 @@
         return localPattern;
     }
 
-    UiaElement UiaElement::BuildUpdatedCache(UiaCacheRequest cacheRequest)
+    UiaElement UiaElement::GetUpdatedCacheElement(UiaCacheRequest cacheRequest)
     {
         auto delegator = UiaOperationScope::GetCurrentDelegator();
         if (delegator && delegator->GetUseRemoteApi())
         {
             ToRemote();
-            return std::get<AutomationRemoteElement>(m_member).BuildUpdatedCache(cacheRequest);
+            return std::get<AutomationRemoteElement>(m_member).GetUpdatedCacheElement(cacheRequest);
         }
 
         const auto& localElement = std::get<winrt::com_ptr<IUIAutomationElement>>(m_member);


### PR DESCRIPTION
`IUIAutomationElement` allows UIA clients to request elements (new objects) with fresh/updated cache information. As it is right now, the UIA operation abstraction library does not support this operation.

The change closes the gap by:
1. Adding `AutomationRemoteElement::GetUpdatedCacheElement` that creates a new element register, sets it to the element to rebuild and then requests to populate its cache with the provided cache request (input),
2. Adding `UiaElement::GetUpdatedCacheElement` to provide the functionality of creating new, rebuilt elements for local and remote operations through the UIA operation abstraction.

The change adds a test that verifies the functionality.

Fixes #26 