### PR TITLE
Add `ForEach`, `ContinueIf` and `BreakIf` to the UIA operation abstraction library

### DIFF
--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1975,6 +1975,23 @@ namespace UiaOperationAbstraction
                 std::forward<ModificationBlock>(modification), std::forward<Body>(body));
         }
 
+        template<class ArrayType, class Body>
+        void ForEach(ArrayType array, Body body)
+        {
+            const auto arraySize = array.Size();
+            UiaUint index{ 0 };
+
+            For(
+                []() {} /* initialize */,
+                [&]() { return (index < arraySize); } /* condition */,
+                [&]() { index += 1; } /* modification */,
+                [&]() /* body */
+                {
+                    const auto element = array.GetAt(index);
+                    body(element);
+                });
+        }
+
         inline void Break()
         {
             GetCurrentDelegator()->Break();
@@ -1983,6 +2000,22 @@ namespace UiaOperationAbstraction
         inline void Continue()
         {
             GetCurrentDelegator()->Continue();
+        }
+
+        void BreakIf(UiaBool condition)
+        {
+            If(condition, [&]()
+            {
+                Break();
+            });
+        }
+
+        void ContinueIf(UiaBool condition)
+        {
+            If(condition, [&]()
+            {
+                Continue();
+            });
         }
 
         inline void AbortOperationWithHresult(HRESULT hr)


### PR DESCRIPTION
Today, iterating over and working with a collection of elements in a `UiaArray` is a relatively verbose process that requires from the code author to create a full-fledged `For` loop that takes multiple lambda expressions (initialize, break condition, post-loop increment and the body of the loop) and variables (size of the collection, element index and collection element).

To make the process smoother, this change adds 3 proposed (in the linked work items) improvements to the UIA operation abstraction library:
* `ContinueIf` that is an equivalent of an `If` statement that -- if met -- skips over the currently processed loop iteration (`continue`),
* `BreakIf` which is a complementary concept to the first one that -- instead of `continue`-ing past the current loop iteration -- `break`s the loop.
* `ForEach` which mimics known, simplified constructs of iterating over elements in a collection and processing them in the order in which the collection exposes them (requiring only the collection to iterate over and the body of the loop to process collection elements).

The change comes with a test that covers all 3 new constructs as a package of improvements around looping over collections of items.

Fixes #22
Fixes #21 