### PR TITLE
Add an ability to multi-bind input and result variables via UIA operation abstraction

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -401,10 +401,7 @@ namespace UiaOperationAbstractionTests
                 auto boundingRectangleHeight = boundingRectangle.GetHeight();
 
                 // Return the field values.
-                operationScope.BindResult(boundingRectangleX);
-                operationScope.BindResult(boundingRectangleY);
-                operationScope.BindResult(boundingRectangleWidth);
-                operationScope.BindResult(boundingRectangleHeight);
+                operationScope.BindResult(boundingRectangleX, boundingRectangleY, boundingRectangleWidth, boundingRectangleHeight);
                 operationScope.Resolve();
 
                 // Convert abstraction types to local types.

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1859,8 +1859,14 @@ namespace UiaOperationAbstraction
         // to remote mode as soon as the remote scope begins, to avoid conditional conversion inside
         // a condition or loop. To abstract this from client code and provide symmetry with BindResult,
         // we provide a BindInput method to do this.
+        template<class... Args>
+        void BindInput(Args&... args)
+        {
+            (BindSingleInput(args), ...);
+        }
+
         template <class WrapperType>
-        void BindInput(WrapperType& value)
+        void BindSingleInput(WrapperType& value)
         {
             // ToRemote will have no effect in a local scope, so we don't need to explicitly check that here.
             value.ToRemote();
@@ -1872,8 +1878,14 @@ namespace UiaOperationAbstraction
         // If the remote operation is NOT local in scope, BindResult will do nothing. If you want to bind
         // a result that is not local in scope, and you're not sure whether your remote operation is local
         // in scope, use BindNonlocalResult.
+        template<class... Args>
+        void BindResult(Args&... args)
+        {
+            (BindSingleResult(args), ...);
+        }
+
         template <class WrapperType>
-        void BindResult(WrapperType& value)
+        void BindSingleResult(WrapperType& value)
         {
             // The remote case only has to do something when resolution would result in executing the
             // remote operation - if this is a continuation of an existing operation, the value remains
@@ -1892,7 +1904,7 @@ namespace UiaOperationAbstraction
                 );
             }
             // In all other cases (strictly local operation, nested remote operation) bind is a no-op.
-        }      
+        }
 
         // BindNonlocalResult is used to bind results that are not local in scope. The binding will be
         // deferred until just before the outermost remote operation is executed, and will execute as a


### PR DESCRIPTION
Currently, when using the UIA operation abstraction library, inputs and results can only be bound to the operation scope one by one. While the functionality is absolutely sufficient to define remote operations with any number of input arguments and output/result values, it creates unnecessarily long, repeating patterns of chains of `BindInput` and `BindResult` calls.

The change adapts the proposed (in the issue) solution for it by adding variadic `BindInput` and `BindResult`. It also modifies one of the tests to use the new version of `BindResult`.

Fixes #5 