### PR TITLE
Fix `ConvertRect` to correctly convert `RECT` to `winrt::Windows::Foundation::Rect`

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -807,5 +807,49 @@ namespace UiaOperationAbstractionTests
         {
             ConvertRectTest(true /* useRemoteOperations */);
         }
+
+        void ConvertRectTest(bool useRemoteOperations)
+        {
+            // Initialize the test application.
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+
+            // Set focus to the display element.
+            auto focusedElement = WaitForElementFocus(L"Display is 0");
+
+            // Initialize the UIA Remote Operation abstraction.
+            const auto cleanup = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            // Create rectangles using 2 different input types and check that they are the same when returned
+            // back to the caller.
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Give this operation a remote context.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                UiaOperationAbstraction::UiaRect win32Rect{ RECT{ 5 /* left */, 5 /* top */, 10 /* right */, 10 /* bottom */} };
+                UiaOperationAbstraction::UiaRect winrtRect{ winrt::Windows::Foundation::Rect{ 5 /* X */, 5 /* Y */, 5 /* Width */, 5 /* Height */} };
+                UiaBool areRectsEqual = (win32Rect == winrtRect);
+
+                // Return the result.
+                operationScope.BindResult(areRectsEqual);
+                operationScope.Resolve();
+
+                // Ensure the two rectangles are equal.
+                Assert::IsTrue(static_cast<bool>(areRectsEqual));
+            }
+        }
+
+        TEST_METHOD(ConvertRectLocal)
+        {
+            ConvertRectTest(false /* useRemoteOperations */);
+        }
+
+        TEST_METHOD(ConvertRectRemote)
+        {
+            ConvertRectTest(true /* useRemoteOperations */);
+        }
     };
 }

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -763,5 +763,49 @@ namespace UiaOperationAbstractionTests
         {
             ForEachLoop(true /* useRemoteOperations */);
         }
+
+        void ConvertRectTest(bool useRemoteOperations)
+        {
+            // Initialize the test application.
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+
+            // Set focus to the display element.
+            auto focusedElement = WaitForElementFocus(L"Display is 0");
+
+            // Initialize the UIA Remote Operation abstraction.
+            const auto cleanup = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            // Create rectangles using 2 different input types and check that they are the same when returned
+            // back to the caller.
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Give this operation a remote context.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                UiaOperationAbstraction::UiaRect win32Rect{ RECT{ 5 /* left */, 5 /* top */, 10 /* right */, 10 /* bottom */} };
+                UiaOperationAbstraction::UiaRect winrtRect{ winrt::Windows::Foundation::Rect{ 5 /* X */, 5 /* Y */, 5 /* Width */, 5 /* Height */} };
+                UiaBool areRectsEqual = (win32Rect == winrtRect);
+
+                // Return the result.
+                operationScope.BindResult(areRectsEqual);
+                operationScope.Resolve();
+
+                // Ensure the two rectangles are equal.
+                Assert::IsTrue(static_cast<bool>(areRectsEqual));
+            }
+        }
+
+        TEST_METHOD(ConvertRectLocal)
+        {
+            ConvertRectTest(false /* useRemoteOperations */);
+        }
+
+        TEST_METHOD(ConvertRectRemote)
+        {
+            ConvertRectTest(true /* useRemoteOperations */);
+        }
     };
 }

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -807,49 +807,5 @@ namespace UiaOperationAbstractionTests
         {
             ConvertRectTest(true /* useRemoteOperations */);
         }
-
-        void ConvertRectTest(bool useRemoteOperations)
-        {
-            // Initialize the test application.
-            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
-            app.Activate();
-
-            // Set focus to the display element.
-            auto focusedElement = WaitForElementFocus(L"Display is 0");
-
-            // Initialize the UIA Remote Operation abstraction.
-            const auto cleanup = InitializeUiaOperationAbstraction(useRemoteOperations);
-
-            // Create rectangles using 2 different input types and check that they are the same when returned
-            // back to the caller.
-            {
-                auto operationScope = UiaOperationScope::StartNew();
-
-                // Give this operation a remote context.
-                UiaElement displayElement{ focusedElement };
-                operationScope.BindInput(displayElement);
-
-                UiaOperationAbstraction::UiaRect win32Rect{ RECT{ 5 /* left */, 5 /* top */, 10 /* right */, 10 /* bottom */} };
-                UiaOperationAbstraction::UiaRect winrtRect{ winrt::Windows::Foundation::Rect{ 5 /* X */, 5 /* Y */, 5 /* Width */, 5 /* Height */} };
-                UiaBool areRectsEqual = (win32Rect == winrtRect);
-
-                // Return the result.
-                operationScope.BindResult(areRectsEqual);
-                operationScope.Resolve();
-
-                // Ensure the two rectangles are equal.
-                Assert::IsTrue(static_cast<bool>(areRectsEqual));
-            }
-        }
-
-        TEST_METHOD(ConvertRectLocal)
-        {
-            ConvertRectTest(false /* useRemoteOperations */);
-        }
-
-        TEST_METHOD(ConvertRectRemote)
-        {
-            ConvertRectTest(true /* useRemoteOperations */);
-        }
     };
 }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -40,7 +40,7 @@ namespace UiaOperationAbstraction
 
         winrt::Windows::Foundation::Rect ConvertRect(RECT rect)
         {
-            winrt::Windows::Foundation::Rect winrtRect(0 /* Height */, 0 /* Width */, static_cast<float>(rect.left), static_cast<float>(rect.top));
+            winrt::Windows::Foundation::Rect winrtRect(static_cast<float>(rect.left), static_cast<float>(rect.top), 0 /* Height */, 0 /* Width */);
             winrtRect.Height = static_cast<float>(rect.bottom - rect.top);
             winrtRect.Width = static_cast<float>(rect.right - rect.left);
 


### PR DESCRIPTION
`winrt::Windows::Foundation::Rect ConvertRect(RECT rect)` is a helper created to convert from Win32 `RECT` to `WinRT` `winrt::Windows::Foundation::Rect` for the purpose of creating `UiaRect` out of the commonly used `RECT` type.

However, currently, the helper incorrectly passes the left and top coordinates of `RECT` as `Height` and `Width` of `winrt::Rect` due to which the resulting `winrt::Rect`s returned by the helper are not correct.

The change fixes the problem by correcting the order of constructor arguments.

Fixes #25 