### PR TITLE
Add support for `Stringify` operations to UIA operation abstraction

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -479,5 +479,158 @@ namespace UiaOperationAbstractionTests
         {
             ArrayEqualityComparisonTest(true);
         }
+
+        void StringifyTest(const bool useRemoteOperations)
+        {
+            // Initialize the test application.
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+
+            // Set focus to the display element.
+            auto focusedElement = WaitForElementFocus(L"Display is 0");
+
+            // Initialize the UIA Remote Operation abstraction.
+            const auto cleanup = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            // Test all types that are convertible to strings:
+            // -> Boolean
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Import the focused element to contextualize the operation to execute.
+                UiaElement displayElement{ focusedElement  };
+                operationScope.BindInput(displayElement);
+
+                // Create values to convert to strings and covert them.
+                UiaBool falseBool{ false };
+                UiaBool trueBool{ true };
+
+                auto falseBoolString = falseBool.Stringify();
+                auto trueBoolString = trueBool.Stringify();
+
+                // Resolve the values.
+                operationScope.BindResult(falseBoolString);
+                operationScope.BindResult(trueBoolString);
+                operationScope.Resolve();
+
+                // And compare them against expectations.
+                Assert::AreEqual(std::wstring(L"false"), falseBoolString.GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"true"), trueBoolString.GetLocalWstring());
+            }
+
+            // -> Numeric
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Import the focused element to contextualize the operation to execute.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                // Create values to convert to strings and covert them.
+                UiaInt intValue{ 5 };
+                UiaUint uintValue{ 7 };
+                UiaDouble doubleValue{ 10.0 };
+
+                auto intValueString = intValue.Stringify();
+                auto uintValueString = uintValue.Stringify();
+                auto doubleValueString = doubleValue.Stringify();
+
+                // Resolve the values.
+                operationScope.BindResult(intValueString);
+                operationScope.BindResult(uintValueString);
+                operationScope.BindResult(doubleValueString);
+                operationScope.Resolve();
+
+                // And compare them against expectations.
+                Assert::AreEqual(std::wstring(L"5"), intValueString.GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"7"), uintValueString.GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"10.0"), doubleValueString.GetLocalWstring());
+            }
+
+            // -> Character
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Import the focused element to contextualize the operation to execute.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                // Create values to convert to strings and covert them.
+                UiaString stringValue{ L"MyString" };
+                UiaChar charValue{ L'M' };
+
+                auto stringValueString = stringValue.Stringify();
+                auto charValueString = charValue.Stringify();
+
+                // Resolve the values.
+                operationScope.BindResult(stringValueString);
+                operationScope.BindResult(charValueString);
+                operationScope.Resolve();
+
+                // And compare them against expectations.
+                Assert::AreEqual(std::wstring(L"MyString"), stringValueString.GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"M"), charValueString.GetLocalWstring());
+            }
+
+            // -> Point and Rectangle
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Import the focused element to contextualize the operation to execute.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                // Create values to convert to strings and covert them.
+                UiaOperationAbstraction::UiaPoint pointValue{ POINT{ 5 /* X */, 5 /* Y */ } };
+                UiaOperationAbstraction::UiaRect rectValue{ winrt::Windows::Foundation::Rect{ 5.0f /* X */, 5.0f /* Y */, 10.0f /* Width */, 10.0f /* Height */ } };
+
+                auto pointValueString = pointValue.Stringify();
+                auto rectValueString = rectValue.Stringify();
+
+                // Resolve the values.
+                operationScope.BindResult(pointValueString);
+                operationScope.BindResult(rectValueString);
+                operationScope.Resolve();
+
+                // And compare them against expectations.
+                Assert::AreEqual(std::wstring(L"Point{ 5, 5 }"), pointValueString.GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"Rect{ 5, 5, 5, 5 }"), rectValueString.GetLocalWstring());
+            }
+
+            // -> Array of type
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Import the focused element to contextualize the operation to execute.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                // Create values to convert to strings and covert them.
+                UiaArray<UiaInt> intArray{ std::vector<int>{ 5, 6, 7 } };
+                UiaArray<UiaString> stringArray{ std::vector<wil::shared_bstr>{ wil::make_bstr(L"String1"), wil::make_bstr(L"String2") } };
+
+                auto intArrayString = intArray.Stringify();
+                auto stringArrayString = stringArray.Stringify();
+
+                // Resolve the values.
+                operationScope.BindResult(intArrayString);
+                operationScope.BindResult(stringArrayString);
+                operationScope.Resolve();
+
+                // And compare them against expectations.
+                Assert::AreEqual(std::wstring(L"[5,6,7]"), intArrayString.GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"[String1, String2]"), stringArrayString.GetLocalWstring());
+            }
+        }
+
+        TEST_METHOD(StringifyTestLocal)
+        {
+            StringifyTest(false /* useRemoteOperations */);
+        }
+
+        TEST_METHOD(StringifyTestRemote)
+        {
+            StringifyTest(true /* useRemoteOperations */);
+        }
     };
 }

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -544,7 +544,7 @@ namespace UiaOperationAbstractionTests
                 // And compare them against expectations.
                 Assert::AreEqual(std::wstring(L"5"), intValueString.GetLocalWstring());
                 Assert::AreEqual(std::wstring(L"7"), uintValueString.GetLocalWstring());
-                Assert::AreEqual(std::wstring(L"10.0"), doubleValueString.GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"10.000000"), doubleValueString.GetLocalWstring());
             }
 
             // -> Character
@@ -593,8 +593,8 @@ namespace UiaOperationAbstractionTests
                 operationScope.Resolve();
 
                 // And compare them against expectations.
-                Assert::AreEqual(std::wstring(L"Point{ 5, 5 }"), pointValueString.GetLocalWstring());
-                Assert::AreEqual(std::wstring(L"Rect{ 5, 5, 5, 5 }"), rectValueString.GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"Point{ 5,5 }"), pointValueString.GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"Rect{ 5,5,10,10 }"), rectValueString.GetLocalWstring());
             }
 
             // -> Array of type
@@ -619,7 +619,7 @@ namespace UiaOperationAbstractionTests
 
                 // And compare them against expectations.
                 Assert::AreEqual(std::wstring(L"[5,6,7]"), intArrayString.GetLocalWstring());
-                Assert::AreEqual(std::wstring(L"[String1, String2]"), stringArrayString.GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"[String1,String2]"), stringArrayString.GetLocalWstring());
             }
         }
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -19,6 +19,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteBool BoolNot();
         AutomationRemoteBool BoolAnd(AutomationRemoteBool rhs);
         AutomationRemoteBool BoolOr(AutomationRemoteBool rhs);
+
+        AutomationRemoteString Stringify();
     }
 
     runtimeclass AutomationRemoteInt : AutomationRemoteObject
@@ -35,6 +37,8 @@ namespace Microsoft.UI.UIAutomation
         void Subtract(AutomationRemoteInt rhs);
         void Multiply(AutomationRemoteInt rhs);
         void Divide(AutomationRemoteInt rhs);
+
+        AutomationRemoteString Stringify();
     }
 
     runtimeclass AutomationRemoteUint : AutomationRemoteObject
@@ -51,6 +55,8 @@ namespace Microsoft.UI.UIAutomation
         void Subtract(AutomationRemoteUint rhs);
         void Multiply(AutomationRemoteUint rhs);
         void Divide(AutomationRemoteUint rhs);
+
+        AutomationRemoteString Stringify();
     }
 
     runtimeclass AutomationRemoteDouble : AutomationRemoteObject
@@ -67,6 +73,8 @@ namespace Microsoft.UI.UIAutomation
         void Subtract(AutomationRemoteDouble rhs);
         void Multiply(AutomationRemoteDouble rhs);
         void Divide(AutomationRemoteDouble rhs);
+
+        AutomationRemoteString Stringify();
     }
 
     runtimeclass AutomationRemoteChar : AutomationRemoteObject
@@ -78,6 +86,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteBool IsLessThanOrEqual(AutomationRemoteChar rhs);
         AutomationRemoteBool IsGreaterThan(AutomationRemoteChar rhs);
         AutomationRemoteBool IsGreaterThanOrEqual(AutomationRemoteChar rhs);
+
+        AutomationRemoteString Stringify();
     }
 
     runtimeclass AutomationRemoteString : AutomationRemoteObject
@@ -91,6 +101,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteString Concat(AutomationRemoteString other);
 
         AutomationRemoteUint Size();
+
+        AutomationRemoteString Stringify();
     }
 
     runtimeclass AutomationRemotePoint : AutomationRemoteObject
@@ -101,6 +113,8 @@ namespace Microsoft.UI.UIAutomation
 
         AutomationRemoteDouble GetX();
         AutomationRemoteDouble GetY();
+
+        AutomationRemoteString Stringify();
     }
 
     runtimeclass AutomationRemoteRect : AutomationRemoteObject
@@ -113,6 +127,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteDouble GetWidth();
         AutomationRemoteDouble GetX();
         AutomationRemoteDouble GetY();
+
+        AutomationRemoteString Stringify();
     }
 
     runtimeclass AutomationRemoteGuid : AutomationRemoteObject
@@ -138,6 +154,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteAnyObject GetAt(AutomationRemoteUint index);
 
         AutomationRemoteUint Size();
+
+        AutomationRemoteString Stringify();
     }
 
     runtimeclass AutomationRemoteStringMap : AutomationRemoteObject

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
@@ -477,6 +477,12 @@ void RemoteOperationInstructionSerializer::Write(const bytecode::CacheRequestAdd
     Write(instruction.patternIdId);
 }
 
+void RemoteOperationInstructionSerializer::Write(const bytecode::Stringify& instruction)
+{
+    Write(instruction.resultId);
+    Write(instruction.targetId);
+}
+
 void RemoteOperationInstructionSerializer::Write(const GetterBase& instruction)
 {
     Write(instruction.resultId);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.h
@@ -112,6 +112,8 @@ private:
     void Write(const bytecode::PopulateCache&);
     void Write(const bytecode::LookupId&);
     void Write(const bytecode::LookupGuid&);
+    void Write(const bytecode::Stringify&);
+
     void Write(const bytecode::GetterBase&);
 #include "RemoteOperationInstructionSerializerMethods.g.h"
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructions.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructions.h
@@ -149,6 +149,8 @@ enum class InstructionType
     CacheRequestAddPattern = 0x4f,
     PopulateCache = 0x50,
 
+    Stringify = 0x51,
+
     // UIA pattern getters and pattern methods
 #include "RemoteOperationInstructionEnumValues.g.h"
 };
@@ -237,6 +239,7 @@ constexpr std::array c_supportedInstructions =
     InstructionType::CacheRequestAddProperty,
     InstructionType::CacheRequestAddPattern,
     InstructionType::PopulateCache,
+    InstructionType::Stringify,
 
     // Auto-generated UIA pattern getters and pattern methods
 #include "RemoteOperationInstructionEnumValuesArray.g.h"
@@ -910,6 +913,14 @@ struct PopulateCache
     OperandId cacheRequestId;
 };
 
+struct Stringify
+{
+    constexpr static InstructionType type = InstructionType::Stringify;
+
+    OperandId resultId;
+    OperandId targetId;
+};
+
 #include "RemoteOperationInstructions.g.h"
 
 using Instruction = std::variant<
@@ -1025,7 +1036,9 @@ using Instruction = std::variant<
     IsStringMap,
     IsElement,
     IsGuid,
-    IsCacheRequest
+    IsCacheRequest,
+
+    Stringify
 
 #include "RemoteOperationInstructionsVariantParams.g.h"
     >;

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -143,11 +143,33 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return result;
     }
 
+    winrt::AutomationRemoteString AutomationRemoteBool::Stringify()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::Stringify{
+            resultId,
+            m_operandId,
+        });
+        const auto result = Make<AutomationRemoteString>(resultId);
+        return result;
+    }
+
     // AutomationRemoteInt
 
     AutomationRemoteInt::AutomationRemoteInt(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
         : base_type(operandId, parent)
     {
+    }
+
+    winrt::AutomationRemoteString AutomationRemoteInt::Stringify()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::Stringify{
+            resultId,
+            m_operandId,
+        });
+        const auto result = Make<AutomationRemoteString>(resultId);
+        return result;
     }
 
     // AutomationRemoteUint
@@ -157,11 +179,33 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     {
     }
 
+    winrt::AutomationRemoteString AutomationRemoteUint::Stringify()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::Stringify{
+            resultId,
+            m_operandId,
+        });
+        const auto result = Make<AutomationRemoteString>(resultId);
+        return result;
+    }
+
     // AutomationRemoteDouble
 
     AutomationRemoteDouble::AutomationRemoteDouble(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
         : base_type(operandId, parent)
     {
+    }
+
+    winrt::AutomationRemoteString AutomationRemoteDouble::Stringify()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::Stringify{
+            resultId,
+            m_operandId,
+        });
+        const auto result = Make<AutomationRemoteString>(resultId);
+        return result;
     }
 
     // AutomationRemoteChar
@@ -204,6 +248,17 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     winrt::AutomationRemoteBool AutomationRemoteChar::IsGreaterThanOrEqual(winrt::AutomationRemoteChar const& rhs)
     {
         return AutomationRemoteObject::IsGreaterThanOrEqual<AutomationRemoteChar>(rhs);
+    }
+
+    winrt::AutomationRemoteString AutomationRemoteChar::Stringify()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::Stringify{
+            resultId,
+            m_operandId,
+        });
+        const auto result = Make<AutomationRemoteString>(resultId);
+        return result;
     }
 
     // AutomationRemoteString
@@ -261,6 +316,17 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return result;
     }
 
+    winrt::AutomationRemoteString AutomationRemoteString::Stringify()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::Stringify{
+            resultId,
+            m_operandId,
+        });
+        const auto result = Make<AutomationRemoteString>(resultId);
+        return result;
+    }
+
     // AutomationRemotePoint
 
     AutomationRemotePoint::AutomationRemotePoint(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
@@ -281,6 +347,17 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         const auto resultId = m_parent->GetNextId();
         m_parent->InsertInstruction(bytecode::GetPointProperty::GetY(resultId, m_operandId));
         const auto result = Make<AutomationRemoteDouble>(resultId);
+        return result;
+    }
+
+    winrt::AutomationRemoteString AutomationRemotePoint::Stringify()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::Stringify{
+            resultId,
+            m_operandId,
+        });
+        const auto result = Make<AutomationRemoteString>(resultId);
         return result;
     }
 
@@ -320,6 +397,17 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         const auto resultId = m_parent->GetNextId();
         m_parent->InsertInstruction(bytecode::GetRectProperty::GetY(resultId, m_operandId));
         const auto result = Make<AutomationRemoteDouble>(resultId);
+        return result;
+    }
+
+    winrt::AutomationRemoteString AutomationRemoteRect::Stringify()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::Stringify{
+            resultId,
+            m_operandId,
+        });
+        const auto result = Make<AutomationRemoteString>(resultId);
         return result;
     }
 
@@ -408,6 +496,17 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
             m_operandId,
         });
         const auto result = Make<AutomationRemoteUint>(resultId);
+        return result;
+    }
+
+    winrt::AutomationRemoteString AutomationRemoteArray::Stringify()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::Stringify{
+            resultId,
+            m_operandId,
+        });
+        const auto result = Make<AutomationRemoteString>(resultId);
         return result;
     }
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -176,6 +176,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteBool BoolNot();
         winrt::AutomationRemoteBool BoolAnd(Microsoft::UI::UIAutomation::AutomationRemoteBool const& rhs);
         winrt::AutomationRemoteBool BoolOr(Microsoft::UI::UIAutomation::AutomationRemoteBool const& rhs);
+
+        winrt::AutomationRemoteString Stringify();
     };
 
     class AutomationRemoteInt : public AutomationRemoteIntT<AutomationRemoteInt, AutomationRemoteObject>
@@ -237,6 +239,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         {
             AutomationRemoteObject::Divide<AutomationRemoteInt>(rhs);
         }
+
+        winrt::AutomationRemoteString Stringify();
     };
 
     class AutomationRemoteUint : public AutomationRemoteUintT<AutomationRemoteUint, AutomationRemoteObject>
@@ -298,6 +302,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         {
             AutomationRemoteObject::Divide<AutomationRemoteUint>(rhs);
         }
+
+        winrt::AutomationRemoteString Stringify();
     };
 
     class AutomationRemoteDouble : public AutomationRemoteDoubleT<AutomationRemoteDouble, AutomationRemoteObject>
@@ -359,6 +365,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         {
             AutomationRemoteObject::Divide<AutomationRemoteDouble>(rhs);
         }
+
+        winrt::AutomationRemoteString Stringify();
     };
 
     struct AutomationRemoteChar : AutomationRemoteCharT<AutomationRemoteChar, Microsoft::UI::UIAutomation::implementation::AutomationRemoteObject>
@@ -372,6 +380,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteBool IsLessThanOrEqual(winrt::AutomationRemoteChar const& rhs);
         winrt::AutomationRemoteBool IsGreaterThan(winrt::AutomationRemoteChar const& rhs);
         winrt::AutomationRemoteBool IsGreaterThanOrEqual(winrt::AutomationRemoteChar const& rhs);
+
+        winrt::AutomationRemoteString Stringify();
     };
 
     class AutomationRemoteString : public AutomationRemoteStringT<AutomationRemoteString, AutomationRemoteObject>
@@ -398,6 +408,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteString Substr(winrt::AutomationRemoteUint const& index, winrt::AutomationRemoteUint const& length);
         winrt::AutomationRemoteString Concat(winrt::AutomationRemoteString const& other);
         winrt::AutomationRemoteUint Size();
+
+        winrt::AutomationRemoteString Stringify();
     };
 
     class AutomationRemotePoint : public AutomationRemotePointT<AutomationRemotePoint, AutomationRemoteObject>
@@ -422,6 +434,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
 
         winrt::AutomationRemoteDouble GetX();
         winrt::AutomationRemoteDouble GetY();
+
+        winrt::AutomationRemoteString Stringify();
     };
 
     class AutomationRemoteRect : public AutomationRemoteRectT<AutomationRemoteRect, AutomationRemoteObject>
@@ -448,6 +462,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteDouble GetWidth();
         winrt::AutomationRemoteDouble GetX();
         winrt::AutomationRemoteDouble GetY();
+
+        winrt::AutomationRemoteString Stringify();
     };
 
     class AutomationRemoteGuid : public AutomationRemoteGuidT<AutomationRemoteGuid, AutomationRemoteObject>
@@ -501,6 +517,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteAnyObject GetAt(winrt::AutomationRemoteUint index);
 
         winrt::AutomationRemoteUint Size();
+
+        winrt::AutomationRemoteString Stringify();
     };
 
     struct AutomationRemoteStringMap : AutomationRemoteStringMapT<AutomationRemoteStringMap, Microsoft::UI::UIAutomation::implementation::AutomationRemoteObject>

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -563,6 +563,21 @@ namespace UiaOperationAbstraction
         m_member = static_cast<wchar_t>(winrt::unbox_value<uint16_t>(result));
     }
 
+    UiaString UiaString::Stringify()
+    {
+        if (ShouldUseRemoteApi())
+        {
+            auto remoteValue = std::get_if<RemoteType>(&m_member);
+            if (remoteValue)
+            {
+                return remoteValue->Stringify();
+            }
+        }
+
+        const auto bstr = get();
+        return (bstr ? bstr : L"");
+    }
+
     void UiaString::FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result)
     {
         if (result)

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <functional>
+#include <sstream>
 
 #include <combaseapi.h>
 #include <UIAutomation.h>

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -867,6 +867,8 @@ namespace UiaOperationAbstraction
         UiaUint Length() const;
         UiaChar At(UiaUint index);
 
+        UiaString Stringify();
+
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -549,6 +549,8 @@ namespace UiaOperationAbstraction
         VariantType m_member;
     };
 
+    class UiaString;
+
     class UiaBool : public UiaTypeBase<BOOL, winrt::Microsoft::UI::UIAutomation::AutomationRemoteBool>
     {
     public:
@@ -593,6 +595,8 @@ namespace UiaOperationAbstraction
         {
             return *this || UiaBool(rhs);
         }
+
+        UiaString Stringify();
 
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
@@ -650,6 +654,8 @@ namespace UiaOperationAbstraction
         void operator-=(UiaInt rhs);
         void operator*=(UiaInt rhs);
         void operator/=(UiaInt rhs);
+
+        UiaString Stringify();
 
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
@@ -735,6 +741,8 @@ namespace UiaOperationAbstraction
         void operator*=(UiaUint rhs);
         void operator/=(UiaUint rhs);
 
+        UiaString Stringify();
+
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
 
@@ -792,6 +800,8 @@ namespace UiaOperationAbstraction
         void operator*=(UiaDouble rhs);
         void operator/=(UiaDouble rhs);
 
+        UiaString Stringify();
+
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
 
@@ -814,6 +824,8 @@ namespace UiaOperationAbstraction
 
         UiaBool operator==(const UiaChar& rhs) const;
         UiaBool operator!=(const UiaChar& rhs) const;
+
+        UiaString Stringify();
 
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
@@ -1020,6 +1032,8 @@ namespace UiaOperationAbstraction
 
         UiaBool operator==(const UiaPoint& rhs) const;
         UiaBool operator!=(const UiaPoint& rhs) const;
+
+        UiaString Stringify();
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
 
@@ -1047,6 +1061,7 @@ namespace UiaOperationAbstraction
         UiaDouble GetX() const;
         UiaDouble GetY() const;
 
+        UiaString Stringify();
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
 
@@ -1349,6 +1364,38 @@ namespace UiaOperationAbstraction
                 wrappedLocal.FromRemoteResult(operationResults.GetAt(index));
                 localValue->emplace_back(static_cast<ItemLocalType>(wrappedLocal));
             }
+        }
+
+        UiaString Stringify()
+        {
+            if (ShouldUseRemoteApi())
+            {
+                auto remoteValue = std::get_if<RemoteType>(&m_member);
+                if (remoteValue)
+                {
+                    return remoteValue->Stringify();
+                }
+            }
+
+            auto localVec = std::get<LocalType>(m_member);
+            std::wostringstream ss;
+            ss << "[";
+
+            const auto size = localVec->size();
+            for (size_t i = 0; i < size; ++i)
+            {
+                if (i != 0)
+                {
+                    ss << L",";
+                }
+
+                ItemWrapperType element = localVec->at(i);
+                ss << element.Stringify().GetLocalWstring();
+            }
+
+            ss << "]";
+
+            return ss.str();
         }
     };
 


### PR DESCRIPTION
**Remote Operations** provide a variety of types that can be used to perform more complex calculations on the provider side. The types range from "simple" numeric types, collections (arrays, maps) to UIA proprietary types (elements, text ranges).

UIA clients often times have to work with the UIA tree, analyze it and perform operations based on relationships between elements in the tree. However, there is no "simple" way of creating and remembering the relationships/associations in **Remote Operations** today.

That is because Remote Operations provide 2 different collection types:
1. Flat arrays,
2. Maps from strings to any object type (supported by UIA).

(2) would be ideal to remember relationships between elements. However, UIA elements identify themselves through `RuntimeId`s that are arrays of `int`s and therefore cannot be used as keys of maps in **Remote Operations**.

This change adds supports for the `Stringify` instruction and adds tools for the instruction to the UIA operation abstraction library to let the consumers of the library use `RuntimeId`s (and other properties, types) as keys of `UiaStringMap`s to create and use (non-flat, tree-like) object associations in **Remote Operations**.

The change comes with tests to cover local and remote usage of the new operation (via the UIA operation abstraction library).

Fixes #33 