### PR TITLE
WinRT Builder: Add GetMetadataValue support

### DIFF
--- a/src/UIAutomation/FunctionalTests/WinRTBuilderTests.cpp
+++ b/src/UIAutomation/FunctionalTests/WinRTBuilderTests.cpp
@@ -497,5 +497,28 @@ namespace WinRTBuilderTests
             Assert::AreEqual(false, winrt::unbox_value<bool>(results.GetResult(eq2Token)));
             Assert::AreEqual(true, winrt::unbox_value<bool>(results.GetResult(eq3Token)));
         }
+
+        // Tests that when the provider doesn't support GetMetadataValue we get the expected result.
+        TEST_METHOD(GetMetadataValueUnsupported)
+        {
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+            auto calc = WaitForElementFocus(L"Display is 0");
+
+            winrt::AutomationRemoteOperation op;
+            auto remoteElement = op.ImportElement(calc.as<winrt::AutomationElement>());
+
+            auto remoteMetadata = remoteElement.GetMetadataValue(op.NewEnum(winrt::AutomationPropertyId::Name), op.NewEnum(winrt::AutomationMetadata::SayAsInterpretAs));
+
+            auto remoteIsNull = remoteMetadata.IsNull();
+
+            auto metadataToken = op.RequestResponse(remoteMetadata);
+            auto isNullToken = op.RequestResponse(remoteIsNull);
+            auto results = op.Execute();
+
+            AssertSucceeded(results.OperationStatus());
+            Assert::AreEqual(true, winrt::unbox_value<bool>(results.GetResult(isNullToken)));
+            Assert::IsTrue(results.GetResult(metadataToken) == nullptr);
+        }
     };
 }

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteAnyObjectMethods.g.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteAnyObjectMethods.g.h
@@ -89,6 +89,7 @@
         winrt::AutomationRemoteHorizontalTextAlignment AsHorizontalTextAlignment();
         winrt::AutomationRemoteLandmarkType AsLandmarkType();
         winrt::AutomationRemoteLiveSetting AsLiveSetting();
+        winrt::AutomationRemoteMetadata AsMetadata();
         winrt::AutomationRemoteNavigateDirection AsNavigateDirection();
         winrt::AutomationRemoteOrientationType AsOrientationType();
         winrt::AutomationRemoteOutlineStyles AsOutlineStyles();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperationMethods.g.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperationMethods.g.h
@@ -19,6 +19,7 @@
         winrt::AutomationRemoteHorizontalTextAlignment NewEnum(AutomationHorizontalTextAlignment initialValue);
         winrt::AutomationRemoteLandmarkType NewEnum(AutomationLandmarkType initialValue);
         winrt::AutomationRemoteLiveSetting NewEnum(AutomationLiveSetting initialValue);
+        winrt::AutomationRemoteMetadata NewEnum(AutomationMetadata initialValue);
         winrt::AutomationRemoteNavigateDirection NewEnum(AutomationNavigateDirection initialValue);
         winrt::AutomationRemoteOrientationType NewEnum(AutomationOrientationType initialValue);
         winrt::AutomationRemoteOutlineStyles NewEnum(AutomationOutlineStyles initialValue);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
@@ -515,7 +515,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         InsertInstruction(bytecode::NewInt{
             resultId,
             static_cast<int>(initialValue)
-            });
+        });
         const auto result = make<AutomationRemoteMetadata>(resultId, *this);
         return result;
     }

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
@@ -489,6 +489,37 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return result;
     }
 
+    AutomationRemoteMetadata::AutomationRemoteMetadata(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
+        : base_type(operandId, parent)
+    {
+    }
+
+    void AutomationRemoteMetadata::Set(const AutomationRemoteMetadata::class_type& rhs)
+    {
+        AutomationRemoteObject::Set<AutomationRemoteMetadata>(rhs);
+    }
+
+    winrt::AutomationRemoteBool AutomationRemoteMetadata::IsEqual(const AutomationRemoteMetadata::class_type& rhs)
+    {
+        return AutomationRemoteObject::IsEqual<AutomationRemoteMetadata>(rhs);
+    }
+
+    winrt::AutomationRemoteBool AutomationRemoteMetadata::IsNotEqual(const AutomationRemoteMetadata::class_type& rhs)
+    {
+        return AutomationRemoteObject::IsNotEqual<AutomationRemoteMetadata>(rhs);
+    }
+
+    winrt::AutomationRemoteMetadata AutomationRemoteOperation::NewEnum(AutomationMetadata initialValue)
+    {
+        const auto resultId = GetNextId();
+        InsertInstruction(bytecode::NewInt{
+            resultId,
+            static_cast<int>(initialValue)
+            });
+        const auto result = make<AutomationRemoteMetadata>(resultId, *this);
+        return result;
+    }
+
     AutomationRemoteNavigateDirection::AutomationRemoteNavigateDirection(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
         : base_type(operandId, parent)
     {
@@ -3515,6 +3546,11 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     winrt::AutomationRemoteLiveSetting AutomationRemoteAnyObject::AsLiveSetting()
     {
         return As<AutomationRemoteLiveSetting>();
+    }
+
+    winrt::AutomationRemoteMetadata AutomationRemoteAnyObject::AsMetadata()
+    {
+        return As<AutomationRemoteMetadata>();
     }
 
     winrt::AutomationRemoteNavigateDirection AutomationRemoteAnyObject::AsNavigateDirection()

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -203,6 +203,8 @@ namespace Microsoft.UI.UIAutomation
         [default_overload] AutomationRemoteAnyObject GetPropertyValue(AutomationRemotePropertyId propertyId);
         AutomationRemoteAnyObject GetPropertyValue(AutomationRemotePropertyId propertyId, AutomationRemoteBool ignoreDefaultValue);
 
+        AutomationRemoteAnyObject GetMetadataValue(AutomationRemotePropertyId propertyId, AutomationRemoteMetadata metadata);
+
         AutomationRemoteElement GetParentElement();
         AutomationRemoteElement GetFirstChildElement();
         AutomationRemoteElement GetLastChildElement();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -548,6 +548,18 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteBool IsNotEqual(AutomationRemoteLiveSetting rhs);
     };
 
+    enum AutomationMetadata
+    {
+        SayAsInterpretAs = 100000,
+    };
+
+    runtimeclass AutomationRemoteMetadata : AutomationRemoteObject
+    {
+        void Set(AutomationRemoteMetadata rhs);
+        AutomationRemoteBool IsEqual(AutomationRemoteMetadata rhs);
+        AutomationRemoteBool IsNotEqual(AutomationRemoteMetadata rhs);
+    };
+
     enum AutomationNavigateDirection
     {
         Parent = 0,
@@ -1625,6 +1637,7 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteHorizontalTextAlignment AsHorizontalTextAlignment();
         AutomationRemoteLandmarkType AsLandmarkType();
         AutomationRemoteLiveSetting AsLiveSetting();
+        AutomationRemoteMetadata AsMetadata();
         AutomationRemoteNavigateDirection AsNavigateDirection();
         AutomationRemoteOrientationType AsOrientationType();
         AutomationRemoteOutlineStyles AsOutlineStyles();
@@ -1679,6 +1692,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteLandmarkType NewEnum(AutomationLandmarkType initialValue);
         [method_name("NewEnumWithLiveSetting")]
         AutomationRemoteLiveSetting NewEnum(AutomationLiveSetting initialValue);
+        [method_name("NewEnumWithMetadata")]
+        AutomationRemoteMetadata NewEnum(AutomationMetadata initialValue);
         [method_name("NewEnumWithNavigateDirection")]
         AutomationRemoteNavigateDirection NewEnum(AutomationNavigateDirection initialValue);
         [method_name("NewEnumWithOrientationType")]

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
@@ -451,6 +451,14 @@ void RemoteOperationInstructionSerializer::Write(const bytecode::PopulateCache& 
     Write(instruction.cacheRequestId);
 }
 
+void RemoteOperationInstructionSerializer::Write(const bytecode::GetMetadataValue& instruction)
+{
+    Write(instruction.resultId);
+    Write(instruction.targetId);
+    Write(instruction.propertyId);
+    Write(instruction.metadataId);
+}
+
 void RemoteOperationInstructionSerializer::Write(const bytecode::LookupId& instruction)
 {
     Write(instruction.resultId);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.h
@@ -110,6 +110,7 @@ private:
     void Write(const bytecode::GetPropertyValue&);
     void Write(const bytecode::Navigate&);
     void Write(const bytecode::PopulateCache&);
+    void Write(const bytecode::GetMetadataValue&);
     void Write(const bytecode::LookupId&);
     void Write(const bytecode::LookupGuid&);
     void Write(const bytecode::Stringify&);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructions.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructions.h
@@ -150,6 +150,7 @@ enum class InstructionType
     PopulateCache = 0x50,
 
     Stringify = 0x51,
+    GetMetadataValue = 0x52,
 
     // UIA pattern getters and pattern methods
 #include "RemoteOperationInstructionEnumValues.g.h"
@@ -240,6 +241,7 @@ constexpr std::array c_supportedInstructions =
     InstructionType::CacheRequestAddPattern,
     InstructionType::PopulateCache,
     InstructionType::Stringify,
+    InstructionType::GetMetadataValue,
 
     // Auto-generated UIA pattern getters and pattern methods
 #include "RemoteOperationInstructionEnumValuesArray.g.h"
@@ -921,6 +923,16 @@ struct Stringify
     OperandId targetId;
 };
 
+struct GetMetadataValue
+{
+    constexpr static InstructionType type = InstructionType::GetMetadataValue;
+
+    OperandId resultId;
+    OperandId targetId;
+    OperandId propertyId;
+    OperandId metadataId;
+};
+
 #include "RemoteOperationInstructions.g.h"
 
 using Instruction = std::variant<
@@ -1011,6 +1023,7 @@ using Instruction = std::variant<
     GetPropertyValue,
     Navigate,
     PopulateCache,
+    GetMetadataValue,
 
     // GUID instructions
     LookupId,

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -622,6 +622,21 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return result;
     }
 
+    winrt::AutomationRemoteAnyObject AutomationRemoteElement::GetMetadataValue(
+        const winrt::AutomationRemotePropertyId& propertyId,
+        const winrt::AutomationRemoteMetadata& metadata)
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::GetMetadataValue{
+            resultId,
+            m_operandId,
+            GetOperandId<AutomationRemotePropertyId>(propertyId),
+            GetOperandId<AutomationRemoteMetadata>(metadata),
+        });
+        const auto result = Make<AutomationRemoteAnyObject>(resultId);
+        return result;
+    }
+
     winrt::AutomationRemoteElement AutomationRemoteElement::Navigate(const winrt::AutomationRemoteInt& direction)
     {
         const auto resultId = m_parent->GetNextId();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.g.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.g.h
@@ -19,6 +19,7 @@
 #include "AutomationRemoteHorizontalTextAlignment.g.h"
 #include "AutomationRemoteLandmarkType.g.h"
 #include "AutomationRemoteLiveSetting.g.h"
+#include "AutomationRemoteMetadata.g.h"
 #include "AutomationRemoteNavigateDirection.g.h"
 #include "AutomationRemoteOrientationType.g.h"
 #include "AutomationRemoteOutlineStyles.g.h"
@@ -212,6 +213,15 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     {
     public:
         AutomationRemoteLiveSetting(bytecode::OperandId operandId, AutomationRemoteOperation& parent);
+        void Set(const class_type& rhs);
+        winrt::AutomationRemoteBool IsEqual(const class_type& rhs);
+        winrt::AutomationRemoteBool IsNotEqual(const class_type& rhs);
+    };
+
+    class AutomationRemoteMetadata : public AutomationRemoteMetadataT<AutomationRemoteMetadata, AutomationRemoteObject>
+    {
+    public:
+        AutomationRemoteMetadata(bytecode::OperandId operandId, AutomationRemoteOperation& parent);
         void Set(const class_type& rhs);
         winrt::AutomationRemoteBool IsEqual(const class_type& rhs);
         winrt::AutomationRemoteBool IsNotEqual(const class_type& rhs);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -563,6 +563,10 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
             const winrt::AutomationRemotePropertyId& propertyId,
             const winrt::AutomationRemoteBool& ignoreDefaultValue);
 
+        winrt::AutomationRemoteAnyObject GetMetadataValue(
+            const winrt::AutomationRemotePropertyId& propertyId,
+            const winrt::AutomationRemoteMetadata& metadata);
+
         winrt::AutomationRemoteElement GetParentElement();
         winrt::AutomationRemoteElement GetFirstChildElement();
         winrt::AutomationRemoteElement GetLastChildElement();

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionEnums.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionEnums.g.h
@@ -64,6 +64,10 @@
         LiveSetting,
         winrt::Microsoft::UI::UIAutomation::AutomationLiveSetting,
         winrt::Microsoft::UI::UIAutomation::AutomationRemoteLiveSetting>;
+    using UiaMetadata = UiaEnum<
+        METADATAID,
+        winrt::Microsoft::UI::UIAutomation::AutomationMetadata,
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteMetadata>;
     using UiaNavigateDirection = UiaEnum<
         NavigateDirection,
         winrt::Microsoft::UI::UIAutomation::AutomationNavigateDirection,


### PR DESCRIPTION
This PR adds support for `GetMetadataValue` to the WinRT Builder library.

The first part of the PR is adding the `AutomationMetadata` enum to the WinRT surface area. This is done by running the (currently still closed-source) code generator to generate all the relevant pieces for an enum based on the information in the classic COM typelib.

The `GetMetadataValue` method added to `AutomationRemoteElement` is then a simple wrapper around the underlying platform Remote Operations VM bytecode instruction, which follows the existing pattern of builder wrappers.

A functional end-to-end test is added, but only for a provider that doesn't support metadata currently (Xaml). The (currently still closed-source) larger test suite in the OS does validate the underlying instruction against providers that do support it. Such a test should be added to this repo once we've migrated the full test suite into the open source repo.

Partially addresses #35 -- C++ Abstraction work is left to be added in a separate PR.