### PR TITLE
Fix `UiaEnum` comparison operators for all types `UiaEnum` can be constructed out of

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -804,5 +804,62 @@ namespace UiaOperationAbstractionTests
         {
             ConvertRectTest(true /* useRemoteOperations */);
         }
+
+        void CompareEnumTest(bool useRemoteOperations)
+        {
+            // Initialize the test application.
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+
+            // Set focus to the display element.
+            auto focusedElement = WaitForElementFocus(L"Display is 0");
+
+            // Initialize the UIA Remote Operation abstraction.
+            const auto cleanup = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            // Create rectangles using 2 different input types and check that they are the same when returned
+            // back to the caller.
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Give this operation a remote context.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                // Ask for the control type of the imported element (which is returned as a `UiaEnum`).
+                auto controlType = displayElement.GetControlType(false /* useCachedApi */);
+
+                // Compare the retrieved `UiaEnum` against different control type value representations.
+                auto equalToAbstractionValue = (controlType == controlType);
+                auto equalToComEnum = (controlType == UIA_TextControlTypeId);
+                auto equalToWinRtEnum = (controlType == winrt::Microsoft::UI::UIAutomation::AutomationControlType::Text);
+
+                auto notEqualToAbstractionValue = (controlType != controlType);
+                auto notEqualToComEnum = (controlType != UIA_TextControlTypeId);
+                auto notEqualToWinRtEnum = (controlType != winrt::Microsoft::UI::UIAutomation::AutomationControlType::Text);
+
+                // Return the results of the comparisons.
+                operationScope.BindResult(equalToAbstractionValue, equalToComEnum, equalToWinRtEnum, notEqualToAbstractionValue, notEqualToComEnum, notEqualToWinRtEnum);
+                operationScope.Resolve();
+
+                // Ensure the correct results have been returned.
+                Assert::IsTrue(static_cast<bool>(equalToAbstractionValue));
+                Assert::IsTrue(static_cast<bool>(equalToComEnum));
+                Assert::IsTrue(static_cast<bool>(equalToWinRtEnum));
+                Assert::IsFalse(static_cast<bool>(notEqualToAbstractionValue));
+                Assert::IsFalse(static_cast<bool>(notEqualToComEnum));
+                Assert::IsFalse(static_cast<bool>(notEqualToWinRtEnum));
+            }
+        }
+
+        TEST_METHOD(CompareEnumLocal)
+        {
+            CompareEnumTest(false /* useRemoteOperations */);
+        }
+
+        TEST_METHOD(CompareEnumRemote)
+        {
+            CompareEnumTest(true /* useRemoteOperations */);
+        }
     };
 }

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -870,8 +870,11 @@ namespace UiaOperationAbstractionTests
             // Initialize the UIA Remote Operation abstraction.
             const auto cleanup = InitializeUiaOperationAbstraction(useRemoteOperations);
 
-            // Create rectangles using 2 different input types and check that they are the same when returned
-            // back to the caller.
+            // Create an operation that fetches a `UiaEnum`-based property value for a UIA element and compare the
+            // value against different values types that can be used to construct that property-specific `UiaEnum`
+            // type.
+            //
+            // This ensures that common ways of comparing `UiaEnum`-based properties work.
             {
                 auto operationScope = UiaOperationScope::StartNew();
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -937,7 +937,7 @@ namespace UiaOperationAbstraction
                 return std::get<StandinT>(mutableThis.m_member).IsEqual(std::get<StandinT>(mutableRhs.m_member));
             }
 
-            return std::get<ComEnumT>(m_member) == static_cast<ComEnumT>(rhs);
+            return std::get<ComEnumT>(m_member) == std::get<ComEnumT>(rhs.m_member);
         }
 
         UiaBool operator!=(const UiaEnum<ComEnumT, WinRTEnumT, StandinT>& rhs) const
@@ -951,7 +951,7 @@ namespace UiaOperationAbstraction
                 return std::get<StandinT>(mutableThis.m_member).IsNotEqual(std::get<StandinT>(mutableRhs.m_member));
             }
 
-            return std::get<ComEnumT>(m_member) != static_cast<ComEnumT>(rhs);
+            return std::get<ComEnumT>(m_member) != std::get<ComEnumT>(rhs.m_member);
         }
 
         template<class T>

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -878,17 +878,17 @@ namespace UiaOperationAbstraction
     public:
         static constexpr VARTYPE c_comVariantType = VT_I4;
 
-        UiaEnum(ComEnumT value): UiaTypeBase(value)
+        UiaEnum(ComEnumT value) : UiaTypeBase(value)
         {
             ToRemote();
         }
 
-        UiaEnum(WinRTEnumT value): UiaTypeBase(static_cast<ComEnumT>(value))
+        UiaEnum(WinRTEnumT value) : UiaTypeBase(static_cast<ComEnumT>(value))
         {
             ToRemote();
         }
 
-        UiaEnum(StandinT remoteValue): UiaTypeBase(remoteValue)
+        UiaEnum(StandinT remoteValue) : UiaTypeBase(remoteValue)
         {
         }
 
@@ -901,34 +901,6 @@ namespace UiaOperationAbstraction
             {
                 delegator->ConvertVariantDataToRemote<ComEnumT, WinRTEnumT, StandinT>(m_member);
             }
-        }
-
-        UiaBool operator==(ComEnumT&& rhs)
-        {
-            if (ShouldUseRemoteApi())
-            {
-                UiaEnum<ComEnumT, WinRTEnumT, StandinT> rhsRemote(rhs);
-                rhsRemote.ToRemote();
-                this->ToRemote();
-
-                return std::get<StandinT>(m_member).IsEqual(std::get<StandinT>(rhsRemote.m_member));
-            }
-
-            return std::get<ComEnumT>(m_member) == rhs;
-        }
-
-        UiaBool operator!=(ComEnumT&& rhs)
-        {
-            if (ShouldUseRemoteApi())
-            {
-                UiaEnum<ComEnumT, WinRTEnumT, StandinT> rhsRemote(rhs);
-                rhsRemote.ToRemote();
-                this->ToRemote();
-
-                return std::get<StandinT>(m_member).IsNotEqual(std::get<StandinT>(rhsRemote.m_member));
-            }
-
-            return std::get<ComEnumT>(m_member) != rhs;
         }
 
         operator ComEnumT() const
@@ -959,6 +931,7 @@ namespace UiaOperationAbstraction
             {
                 m_member = std::get<ComEnumT>(other.m_member);
             }
+
             return *this;
         }
 
@@ -973,7 +946,7 @@ namespace UiaOperationAbstraction
                 return std::get<StandinT>(mutableThis.m_member).IsEqual(std::get<StandinT>(mutableRhs.m_member));
             }
 
-            return std::get<ComEnumT>(m_member) == rhs;
+            return std::get<ComEnumT>(m_member) == static_cast<ComEnumT>(rhs);
         }
 
         UiaBool operator!=(const UiaEnum<ComEnumT, WinRTEnumT, StandinT>& rhs) const
@@ -987,27 +960,21 @@ namespace UiaOperationAbstraction
                 return std::get<StandinT>(mutableThis.m_member).IsNotEqual(std::get<StandinT>(mutableRhs.m_member));
             }
 
-            return std::get<ComEnumT>(m_member) != rhs;
+            return std::get<ComEnumT>(m_member) != static_cast<ComEnumT>(rhs);
         }
 
-        UiaBool operator==(WinRTEnumT rhs)
+        template<class T>
+        UiaBool operator==(T rhs) const
         {
-            return *this == UiaEnum<ComEnumT, WinRTEnumT, StandinT>(rhs);
+            return (*this == UiaEnum<ComEnumT, WinRTEnumT, StandinT>(rhs));
         }
 
-        UiaBool operator!=(WinRTEnumT rhs)
+        template<class T>
+        UiaBool operator!=(T rhs) const
         {
-            return *this != UiaEnum<ComEnumT, WinRTEnumT, StandinT>(rhs);
+            return (*this != UiaEnum<ComEnumT, WinRTEnumT, StandinT>(rhs));
         }
 
-        UiaBool operator==(ComEnumT rhs) const
-        {
-            return *this == UiaEnum<ComEnumT, WinRTEnumT, StandinT>(rhs);
-        }
-        UiaBool operator!=(ComEnumT rhs) const
-        {
-            return *this != UiaEnum<ComEnumT, WinRTEnumT, StandinT>(rhs);
-        }
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result)
         {
             int intValueOfEnum = winrt::unbox_value<int>(result);

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -894,15 +894,6 @@ namespace UiaOperationAbstraction
 
         UiaEnum(const UiaEnum<ComEnumT, WinRTEnumT, StandinT>&) = default;
 
-        void ToRemote()
-        {
-            auto delegator = UiaOperationScope::GetCurrentDelegator();
-            if (delegator)
-            {
-                delegator->ConvertVariantDataToRemote<ComEnumT, WinRTEnumT, StandinT>(m_member);
-            }
-        }
-
         operator ComEnumT() const
         {
             return std::get<ComEnumT>(m_member);
@@ -979,6 +970,15 @@ namespace UiaOperationAbstraction
         {
             int intValueOfEnum = winrt::unbox_value<int>(result);
             m_member = static_cast<ComEnumT>(intValueOfEnum);
+        }
+
+        void ToRemote()
+        {
+            auto delegator = UiaOperationScope::GetCurrentDelegator();
+            if (delegator)
+            {
+                delegator->ConvertVariantDataToRemote<ComEnumT, WinRTEnumT, StandinT>(m_member);
+            }
         }
     };
 


### PR DESCRIPTION
`UiaEnum` is a wrapper type that can be constructed out of the following types:
1. COM `enum`s such as `CONTROLTYPEID` (local type),
2. WinRT `enum`s of the operation builder such as `AutomationControlType` (local type),
3. Corresponding stand-in (numeric) type (remote type),
4. `UiaEnum` itself (copy-construction).

The abstraction class is providing 3 different types of comparison methods against the mentioned values depending on what the caller has. In short, `UiaEnum` allows comparing against COM, WinRT `enum`s as well as the `UiaEnum` type (the abstraction tries to hide the corresponding stand-in type).

However, this does not work today due to ambiguity of defined comparison operators (and which should be applied for which situation/type).

In fact, the only comparison operators that work are the ones for numeric values (such as `CONTROLTYPEID` cast to `long` in case of `UiaControlType`) and WinRT `enum`s (such as the `AutomationControlType` `enum class`). But these comparators cannot be applied when the code author tries to write UIA operation abstraction-based functions that take UIA abstraction types as the functions usually cannot assume whether abstraction types hold "local" or "remote" types (and therefore casting `UiaEnum`s is not an option).

This change attempts to fix that problem by:
1. Keeping the comparison operators for comparing `UiaEnum`s,
2. Reduces other operators to template-based functions that take a value to compare a `UiaEnum` against, create a `UiaEnum` out of the value and then compares the two (using the kept operators).
3. Removing any other defined comparison operators for the COM and WinRT `enum` types as well as the `rvalue` comparison types.

With the change, ensuring type correctness is pushed towards `UiaEnum` constructors since the operators create `UiaEnum` instances out of `rhs` before comparing values.

Fixes #38