### PR TITLE
Add necessary constructs to `UiaArray` and `UiaStringMap` to enable nesting the collections in other collections

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -11,6 +11,57 @@
 
 using namespace UiaOperationAbstraction;
 
+// Test framework extensions used for comparing and printing different types via the
+// `Assert` test functions.
+namespace Microsoft::VisualStudio::CppUnitTestFramework
+{
+#pragma warning(push)
+#pragma warning(disable: 4505)
+    template<>
+    std::wstring ToString(const std::vector<int>& vec)
+#pragma warning(pop)
+    {
+        std::wstringstream ss;
+        ss << L"[";
+
+        for (size_t i = 0; i < vec.size(); ++i)
+        {
+            if (i != 0)
+            {
+                ss << L", ";
+            }
+
+            ss << vec[i];
+        }
+
+        ss << L"]";
+        return ss.str();
+    }
+
+#pragma warning(push)
+#pragma warning(disable: 4505)
+    template<>
+    std::wstring ToString(const std::map<std::wstring, int>& map)
+#pragma warning(pop)
+    {
+        std::wstringstream ss;
+        ss << L"{";
+
+        for (const auto& mapEntry : map)
+        {
+            ss << L"\n    <" << mapEntry.first << L", " << mapEntry.second << "L>,";
+        }
+
+        if (!map.empty())
+        {
+            ss << L"\n";
+        }
+
+        ss << L"}";
+        return ss.str();
+    }
+}
+
 namespace UiaOperationAbstractionTests
 {
     // Detect whether a type can be returned from a remote operation. A user
@@ -916,6 +967,189 @@ namespace UiaOperationAbstractionTests
         TEST_METHOD(CompareEnumRemote)
         {
             CompareEnumTest(true /* useRemoteOperations */);
+        }
+
+        void UiaArrayInCollectionsTest(bool useRemoteOperations)
+        {
+            // Initialize the test application.
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+
+            // Set focus to the display element.
+            auto focusedElement = WaitForElementFocus(L"Display is 0");
+
+            // Initialize the UIA Remote Operation abstraction.
+            const auto cleanup = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            // This test creates `UiaArray` instances, builds an array out of them. The returned array
+            // of arrays is tested against the expectations.
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Give this operation a remote context.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                // Construct a few arrays and create a collection out of them.
+                const std::vector<int> baseValueArray{ 1, 2 };
+                UiaArray<UiaInt> array1{ baseValueArray };
+                UiaArray<UiaInt> array2{ baseValueArray };
+
+                UiaArray<UiaArray<UiaInt>> arrays;
+                arrays.Append(array1);
+                arrays.Append(array2);
+
+                // Return the collection of arrays.
+                operationScope.BindResult(arrays);
+                operationScope.Resolve();
+
+                // Ensure the array is of the expected shape.
+                const auto arraysSize = static_cast<unsigned int>(arrays.Size());
+                Assert::AreEqual(static_cast<unsigned int>(2), arraysSize);
+
+                for (unsigned int i = 0; i < arraysSize; ++i)
+                {
+                    const auto array = arrays.GetAt(i);
+                    const auto& localArray = *array;
+                    Assert::AreEqual(baseValueArray, localArray);
+                }
+            }
+
+            // Perform the same test but with `UiaStringMap`.
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Give this operation a remote context.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                // Construct arrays of values and a map out of the arrays.
+                const std::vector<int> baseValueArray{ 1, 2 };
+                UiaArray<UiaInt> array1{ baseValueArray };
+                UiaArray<UiaInt> array2{ baseValueArray };
+
+                UiaStringMap<UiaArray<UiaInt>> arrayMap;
+                arrayMap.Insert(UiaString{ L"array1" }, array1);
+                arrayMap.Insert(UiaString{ L"array2" }, array2);
+
+                // Return the collection.
+                operationScope.BindResult(arrayMap);
+                operationScope.Resolve();
+
+                // Now, make sure the map contains the expected values.
+                Assert::AreEqual(static_cast<size_t>(2), static_cast<size_t>(arrayMap.Size()));
+
+                const std::array<std::wstring, 2> arrayKeys{ L"array1", L"array2" };
+                for (const auto& arrayKey : arrayKeys)
+                {
+                    Assert::IsTrue(arrayMap.HasKey(arrayKey));
+
+                    const auto array = arrayMap.Lookup(arrayKey);
+                    const auto& localArray = *array;
+                    Assert::AreEqual(baseValueArray, localArray);
+                }
+            }
+        }
+
+        TEST_METHOD(UiaArrayInCollectionsTestLocal)
+        {
+            UiaArrayInCollectionsTest(false /* useRemoteOperations */);
+        }
+
+        TEST_METHOD(UiaArrayInCollectionsTestRemote)
+        {
+            UiaArrayInCollectionsTest(true /* useRemoteOperations */);
+        }
+
+        void UiaStringMapInCollectionsTest(bool useRemoteOperations)
+        {
+            // Initialize the test application.
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+
+            // Set focus to the display element.
+            auto focusedElement = WaitForElementFocus(L"Display is 0");
+
+            // Initialize the UIA Remote Operation abstraction.
+            const auto cleanup = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            // This test creates `UiaStringMap` instances, builds an array out of them and returns the array.
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Give this operation a remote context.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                // Construct a few map and create an array out of them.
+                const std::map<std::wstring, int> baseValueMap{ { L"Value", 1 } };
+                UiaStringMap<UiaInt> map1{ baseValueMap };
+                UiaStringMap<UiaInt> map2{ baseValueMap };
+
+                UiaArray<UiaStringMap<UiaInt>> maps;
+                maps.Append(map1);
+                maps.Append(map2);
+
+                // Return the collection of maps.
+                operationScope.BindResult(maps);
+                operationScope.Resolve();
+
+                // Ensure the array is of the expected shape.
+                const auto mapsSize = static_cast<unsigned int>(maps.Size());
+                Assert::AreEqual(static_cast<unsigned int>(2), mapsSize);
+
+                for (unsigned int i = 0; i < mapsSize; ++i)
+                {
+                    const auto map = maps.GetAt(i);
+                    const auto& localMap = *map;
+                    Assert::AreEqual(baseValueMap, localMap);
+                }
+            }
+
+            // Perform the same test but with `UiaStringMap`.
+            {
+                auto operationScope = UiaOperationScope::StartNew();
+
+                // Give this operation a remote context.
+                UiaElement displayElement{ focusedElement };
+                operationScope.BindInput(displayElement);
+
+                // Construct a map of maps.
+                const std::map<std::wstring, int> baseValueMap{ { L"Value", 1 } };
+                UiaStringMap<UiaInt> map1{ baseValueMap };
+                UiaStringMap<UiaInt> map2{ baseValueMap };
+
+                UiaStringMap<UiaStringMap<UiaInt>> mapMap;
+                mapMap.Insert(UiaString{ L"map1" }, map1);
+                mapMap.Insert(UiaString{ L"map2" }, map2);
+
+                // Return the map of maps.
+                operationScope.BindResult(mapMap);
+                operationScope.Resolve();
+
+                // Now, make sure the map is of the expected shape.
+                Assert::AreEqual(static_cast<size_t>(2), static_cast<size_t>(mapMap.Size()));
+
+                const std::array<std::wstring, 2> mapKeys{ L"map1", L"map2" };
+                for (const auto& mapKey : mapKeys)
+                {
+                    Assert::IsTrue(mapMap.HasKey(mapKey));
+
+                    const auto map = mapMap.Lookup(mapKey);
+                    const auto& localMap = *map;
+                    Assert::AreEqual(baseValueMap, localMap);
+                }
+            }
+        }
+
+        TEST_METHOD(UiaStringMapInCollectionsTestLocal)
+        {
+            UiaStringMapInCollectionsTest(false /* useRemoteOperations */);
+        }
+
+        TEST_METHOD(UiaStringMapInCollectionsTestRemote)
+        {
+            UiaStringMapInCollectionsTest(true /* useRemoteOperations */);
         }
     };
 }

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -1029,8 +1029,8 @@ namespace UiaOperationAbstractionTests
                 UiaArray<UiaInt> array2{ baseValueArray };
 
                 UiaStringMap<UiaArray<UiaInt>> arrayMap;
-                arrayMap.Insert(UiaString{ L"array1" }, array1);
-                arrayMap.Insert(UiaString{ L"array2" }, array2);
+                arrayMap.Insert(L"array1", array1);
+                arrayMap.Insert(L"array2", array2);
 
                 // Return the collection.
                 operationScope.BindResult(arrayMap);
@@ -1120,8 +1120,8 @@ namespace UiaOperationAbstractionTests
                 UiaStringMap<UiaInt> map2{ baseValueMap };
 
                 UiaStringMap<UiaStringMap<UiaInt>> mapMap;
-                mapMap.Insert(UiaString{ L"map1" }, map1);
-                mapMap.Insert(UiaString{ L"map2" }, map2);
+                mapMap.Insert(L"map1", map1);
+                mapMap.Insert(L"map2", map2);
 
                 // Return the map of maps.
                 operationScope.BindResult(mapMap);

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1139,6 +1139,9 @@ namespace UiaOperationAbstraction
     public:
         using ItemLocalType = typename ItemWrapperType::LocalType;
 
+        static constexpr auto c_anyTest = &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::IsArray;
+        static constexpr auto c_anyCast = &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsArray;
+
         UiaArray():
             UiaArray(std::vector<ItemLocalType>())
         {
@@ -1146,6 +1149,11 @@ namespace UiaOperationAbstraction
 
         UiaArray(std::vector<ItemLocalType> vector):
             UiaTypeBase(std::make_shared<std::vector<ItemLocalType>>(std::move(vector)))
+        {
+            ToRemote();
+        }
+
+        UiaArray(const std::shared_ptr<std::vector<ItemLocalType>>& value) : UiaTypeBase(value)
         {
             ToRemote();
         }
@@ -1190,6 +1198,11 @@ namespace UiaOperationAbstraction
 
         UiaBool operator!() const { return IsNull(); }
         operator UiaBool() const { return !IsNull(); }
+
+        operator std::shared_ptr<std::vector<ItemLocalType>>() const
+        {
+            return std::get<std::shared_ptr<std::vector<ItemLocalType>>>(m_member);
+        }
 
         std::vector<ItemLocalType>& operator*()
         {
@@ -1379,6 +1392,9 @@ namespace UiaOperationAbstraction
     public:
         using ItemLocalType = typename ItemWrapperType::LocalType;
 
+        static constexpr auto c_anyTest = &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::IsStringMap;
+        static constexpr auto c_anyCast = &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsStringMap;
+
         UiaStringMap():
             UiaStringMap(std::map<std::wstring, ItemLocalType>())
         {
@@ -1386,6 +1402,11 @@ namespace UiaOperationAbstraction
 
         UiaStringMap(std::map<std::wstring, ItemLocalType> map):
             UiaTypeBase(std::make_shared<std::map<std::wstring, ItemLocalType>>(std::move(map)))
+        {
+            ToRemote();
+        }
+
+        UiaStringMap(const std::shared_ptr<std::map<std::wstring, ItemLocalType>>& value) : UiaTypeBase(value)
         {
             ToRemote();
         }
@@ -1419,6 +1440,11 @@ namespace UiaOperationAbstraction
 
         UiaBool operator!() const { return IsNull(); }
         operator UiaBool() const { return !IsNull(); }
+
+        operator std::shared_ptr<std::map<std::wstring, ItemLocalType>>() const
+        {
+            return std::get<std::shared_ptr<std::map<std::wstring, ItemLocalType>>>(m_member);
+        }
 
         std::map<std::wstring, ItemLocalType>& operator*()
         {


### PR DESCRIPTION
To enable putting items in `UiaArray` and `UiaStringMap` (as values, not keys), a wrapper type has to:
1. Provide a constructor that takes the wrapper's local type (such as `std::shared_ptr<std::vector<T>>` in case of `UiaArray`),
2. Provide a constructor that takes the remote type (such as `AutomationRemoteArray` for `UiaArray`s),
3. Provide cast definitions to desired types (`c_anyTest` and `c_anyCast`) to let the collections determine collection element types.
4. Conversion operator from the wrapper type to the local type (such as the already `std::shared_ptr<std::vector<T>>` type in case of `UiaArray`).

Currently, neither `UiaArray` nor `UiaStringMap` meet the requirements and therefore they cannot be used as element types of other collections.

While the situations of nesting collections might not be common right now, there are cases where having that support would be useful especially if the UIA operation abstraction library could provide support for variadic types such as tuples (to hold multiple different types on every index or under every key of the aforementioned collections).

The change aims to enable such future improvements.

----

This change fixes the problem by adjusting the definitions of the two types by adding the necessary definitions. The change comes with the tests to cover the 4 currently supported situations of nesting:
1. `UiaArray` in `UiaArray`,
2. `UiaArray` in `UiaStringMap`,
3. `UiaStringMap` in `UiaArray`,
4. `UiaStringMap` in `UiaStringMap`.

Fixes #42