### PR TITLE
Add support for `UiaTuple` to the UIA operation abstraction library

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -1319,7 +1319,7 @@ namespace UiaOperationAbstractionTests
                 operationScope.Resolve();
 
                 // Ensure the tuple is equal to the default numeric tuple.
-                Assert::AreEqual(std::tuple<int>(0), *tuple.Get<0>());
+                Assert::AreEqual(std::tuple<int>{ 0 }, *tuple.Get<0>());
             }
         }
 

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -1231,13 +1231,13 @@ namespace UiaOperationAbstractionTests
                     // Note: Assumes `tuple` contains local values only.
                     static LocalTupleResult FromResult(UiaTuple<UiaElement, UiaInt, UiaBool, UiaString>& tuple)
                     {
-                        auto element = tuple.GetAt<0>();
+                        auto element = tuple.Get<0>();
                         return LocalTupleResult
                         {
                             (!element.IsNull() ? element.GetName().GetLocalWstring() : L"") /* name */,
-                            tuple.GetAt<1>() /* numericValue */,
-                            tuple.GetAt<2>() /* booleanValue */,
-                            tuple.GetAt<3>().GetLocalWstring() /* stringValue */
+                            tuple.Get<1>() /* numericValue */,
+                            tuple.Get<2>() /* booleanValue */,
+                            tuple.Get<3>().GetLocalWstring() /* stringValue */
                         };
                     }
 
@@ -1319,7 +1319,7 @@ namespace UiaOperationAbstractionTests
                 operationScope.Resolve();
 
                 // Ensure the tuple is equal to the default numeric tuple.
-                Assert::AreEqual(std::tuple<int>(0), *tuple.GetAt<0>());
+                Assert::AreEqual(std::tuple<int>(0), *tuple.Get<0>());
             }
         }
 
@@ -1360,7 +1360,7 @@ namespace UiaOperationAbstractionTests
                 UiaTuple<UiaVariant, UiaVariant> tuple{ UiaVariant{ variantValue }, UiaVariant{} };
 
                 // Get the variant and try to get basic information about it.
-                auto variant = tuple.GetAt<0>();
+                auto variant = tuple.Get<0>();
                 auto isVariantString = variant.IsString();
 
                 UiaString variantString{ L"" };
@@ -1370,7 +1370,7 @@ namespace UiaOperationAbstractionTests
                 });
 
                 // Also, get the empty variant information.
-                auto emptyVariant = tuple.GetAt<1>();
+                auto emptyVariant = tuple.Get<1>();
                 auto isEmptyVariantString = emptyVariant.IsString();
 
                 // Return the tuple for the operation and also information about the two variants.
@@ -1387,11 +1387,11 @@ namespace UiaOperationAbstractionTests
 
                 // Finally, ensure the variants in the returned `UiaTuple` instance matches the two just-checked
                 // variants.
-                auto variantWrapper = tuple.GetAt<0>();
+                auto variantWrapper = tuple.Get<0>();
                 Assert::IsTrue(static_cast<bool>(variantWrapper.IsString()));
                 Assert::AreEqual(variantValue, variantWrapper.AsString().GetLocalWstring());
 
-                auto emptyVariantWrapper = tuple.GetAt<1>();
+                auto emptyVariantWrapper = tuple.Get<1>();
                 Assert::IsFalse(static_cast<bool>(emptyVariantWrapper.IsString()));
                 Assert::AreEqual(static_cast<int>(VT_EMPTY), static_cast<int>(emptyVariantWrapper.get().vt));
             }
@@ -1444,8 +1444,8 @@ namespace UiaOperationAbstractionTests
                 operationScope.Resolve();
 
                 // Ensure the tuple contains the two collections.
-                Assert::AreEqual(baseValueArray, *tuple.GetAt<0>());
-                Assert::AreEqual(baseValueMap, *tuple.GetAt<1>());
+                Assert::AreEqual(baseValueArray, *tuple.Get<0>());
+                Assert::AreEqual(baseValueMap, *tuple.Get<1>());
             }
         }
 
@@ -1487,7 +1487,7 @@ namespace UiaOperationAbstractionTests
 
                 // Modify the string values and tuple fields.
                 modifiedStringValue = L"ModifiedString";
-                tuple.SetAt<3>(wil::make_bstr(L"OwnedModifiedString"));
+                tuple.Set<3>(wil::make_bstr(L"OwnedModifiedString"));
 
                 // Return the results of the comparisons.
                 operationScope.BindResult(immutableStringValue, modifiedStringValue, tuple);
@@ -1498,10 +1498,10 @@ namespace UiaOperationAbstractionTests
                 Assert::AreEqual(std::wstring(L"ImmutableString"), immutableStringValue.GetLocalWstring());
                 Assert::AreEqual(std::wstring(L"ModifiedString"), modifiedStringValue.GetLocalWstring());
 
-                Assert::AreEqual(std::wstring(L"ImmutableString"), tuple.GetAt<0>().GetLocalWstring());
-                Assert::AreEqual(std::wstring(L"UnmodifiedString"), tuple.GetAt<1>().GetLocalWstring());
-                Assert::AreEqual(std::wstring(L"OwnedImmutableString"), tuple.GetAt<2>().GetLocalWstring());
-                Assert::AreEqual(std::wstring(L"OwnedModifiedString"), tuple.GetAt<3>().GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"ImmutableString"), tuple.Get<0>().GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"UnmodifiedString"), tuple.Get<1>().GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"OwnedImmutableString"), tuple.Get<2>().GetLocalWstring());
+                Assert::AreEqual(std::wstring(L"OwnedModifiedString"), tuple.Get<3>().GetLocalWstring());
             }
         }
 
@@ -1540,14 +1540,14 @@ namespace UiaOperationAbstractionTests
                 UiaTuple<UiaString, UiaInt> tuple2{ L"tuple2.string", 2 };
 
                 // Modify `tuple1` by replacing its numeric value with `tuple2`'s.
-                auto tuple1PreviousInt = tuple1.GetAt<1>();
-                auto tuple2Int = tuple2.GetAt<1>();
-                tuple1.SetAt<1>(tuple2Int);
+                auto tuple1PreviousInt = tuple1.Get<1>();
+                auto tuple2Int = tuple2.Get<1>();
+                tuple1.Set<1>(tuple2Int);
 
                 // Use the string field of `tuple1` to modify the string field of `tuple2`.
-                auto tuple2PreviousString = tuple2.GetAt<0>();
-                auto tuple1String = tuple1.GetAt<0>();
-                tuple2.SetAt<0>(tuple1String);
+                auto tuple2PreviousString = tuple2.Get<0>();
+                auto tuple1String = tuple1.Get<0>();
+                tuple2.Set<0>(tuple1String);
 
                 // Return the tuples and the previous values, too.
                 operationScope.BindResult(tuple1, tuple2, tuple1PreviousInt, tuple2PreviousString);
@@ -1556,7 +1556,7 @@ namespace UiaOperationAbstractionTests
                 // Ensure the returned comparison results are correct.
                 const auto toLocalTupleResult = [](auto& tuple)
                 {
-                    return std::tuple<std::wstring, int>{ tuple.GetAt<0>().GetLocalWstring(), tuple.GetAt<1>() };
+                    return std::tuple<std::wstring, int>{ tuple.Get<0>().GetLocalWstring(), tuple.Get<1>() };
                 };
 
                 Assert::AreEqual(1, static_cast<int>(tuple1PreviousInt));
@@ -1671,8 +1671,8 @@ namespace UiaOperationAbstractionTests
                     auto tuple = tupleArray.GetAt(i);
 
                     const auto tupleKeyPrefix = tupleKey + L".";
-                    Assert::AreEqual(tupleKeyPrefix + L"string1", tuple.GetAt<0>().GetLocalWstring());
-                    Assert::AreEqual(tupleKeyPrefix + L"string2", tuple.GetAt<1>().GetLocalWstring());
+                    Assert::AreEqual(tupleKeyPrefix + L"string1", tuple.Get<0>().GetLocalWstring());
+                    Assert::AreEqual(tupleKeyPrefix + L"string2", tuple.Get<1>().GetLocalWstring());
                 }
             }
 
@@ -1707,8 +1707,8 @@ namespace UiaOperationAbstractionTests
 
                     auto tuple = tupleMap.Lookup(tupleKey);
                     const auto tupleKeyPrefix = tupleKey + L".";
-                    Assert::AreEqual(tupleKeyPrefix + L"string1", tuple.GetAt<0>().GetLocalWstring());
-                    Assert::AreEqual(tupleKeyPrefix + L"string2", tuple.GetAt<1>().GetLocalWstring());
+                    Assert::AreEqual(tupleKeyPrefix + L"string1", tuple.Get<0>().GetLocalWstring());
+                    Assert::AreEqual(tupleKeyPrefix + L"string2", tuple.Get<1>().GetLocalWstring());
                 }
             }
         }

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -15,11 +15,8 @@ using namespace UiaOperationAbstraction;
 // `Assert` test functions.
 namespace Microsoft::VisualStudio::CppUnitTestFramework
 {
-#pragma warning(push)
-#pragma warning(disable: 4505)
     template<>
     std::wstring ToString(const std::vector<int>& vec)
-#pragma warning(pop)
     {
         std::wstringstream ss;
         ss << L"[";
@@ -38,11 +35,8 @@ namespace Microsoft::VisualStudio::CppUnitTestFramework
         return ss.str();
     }
 
-#pragma warning(push)
-#pragma warning(disable: 4505)
     template<>
     std::wstring ToString(const std::map<std::wstring, int>& map)
-#pragma warning(pop)
     {
         std::wstringstream ss;
         ss << L"{";
@@ -61,22 +55,16 @@ namespace Microsoft::VisualStudio::CppUnitTestFramework
         return ss.str();
     }
 
-#pragma warning(push)
-#pragma warning(disable: 4505)
     template<>
     std::wstring ToString(const std::tuple<int>& tuple)
-#pragma warning(pop)
     {
         std::wstringstream ss;
         ss << L"<" << std::get<0>(tuple) << L">";
         return ss.str();
     }
 
-#pragma warning(push)
-#pragma warning(disable: 4505)
     template<>
     std::wstring ToString(const std::tuple<std::wstring, int>& tuple)
-#pragma warning(pop)
     {
         std::wstringstream ss;
         ss << L"<" << std::get<0>(tuple) << L", " << std::get<1>(tuple) << L">";

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -55,20 +55,46 @@ namespace Microsoft::VisualStudio::CppUnitTestFramework
         return ss.str();
     }
 
+    template<std::size_t I, class... Args>
+    void TupleToStringStream([[maybe_unused]] const std::tuple<Args...>& tuple, [[maybe_unused]] std::wstringstream& stream)
+    {
+        if constexpr (I < sizeof...(Args))
+        {
+            // Add the current field/value of the tuple.
+            if constexpr (I != 0)
+            {
+                stream << L", ";
+            }
+
+            stream << std::get<I>(tuple);
+
+            // And move to adding the next onto to the stream (if any remain).
+            TupleToStringStream<I + 1>(tuple, stream);
+        }
+    }
+
+    template<class... Args>
+    std::wstring TupleToString(const std::tuple<Args...>& tuple)
+    {
+        std::wstringstream ss;
+
+        ss << L"<";
+        TupleToStringStream<0>(tuple, ss);
+        ss << L">";
+
+        return ss.str();
+    }
+
     template<>
     std::wstring ToString(const std::tuple<int>& tuple)
     {
-        std::wstringstream ss;
-        ss << L"<" << std::get<0>(tuple) << L">";
-        return ss.str();
+        return TupleToString(tuple);
     }
 
     template<>
     std::wstring ToString(const std::tuple<std::wstring, int>& tuple)
     {
-        std::wstringstream ss;
-        ss << L"<" << std::get<0>(tuple) << L", " << std::get<1>(tuple) << L">";
-        return ss.str();
+        return TupleToString(tuple);
     }
 }
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -385,6 +385,10 @@ namespace UiaOperationAbstraction
 
             switch (type)
             {
+            case winrt::Windows::Foundation::PropertyType::Empty:
+                variant.vt = VT_EMPTY;
+                break;
+
             case winrt::Windows::Foundation::PropertyType::Boolean:
                 variant.vt = VT_BOOL;
                 variant.boolVal = winrt::unbox_value<bool>(propertyValue) ? VARIANT_TRUE : VARIANT_FALSE;
@@ -909,6 +913,9 @@ namespace UiaOperationAbstraction
                 auto localVariant = *localVariantPointer;
                 switch (localVariant->vt)
                 {
+                case VT_EMPTY:
+                    localVariantVariant = m_remoteOperation.NewNull();
+                    break;
                 case VT_BOOL:
                     localVariantVariant = m_remoteOperation.NewBool(localVariant->boolVal ? true : false);
                     break;
@@ -1811,6 +1818,10 @@ namespace UiaOperationAbstraction
         return BinaryOperator<UiaHwnd, NotEqual>(this->m_member, rhs.m_member);
     }
 
+    UiaVariant::UiaVariant() : UiaVariant(wil::unique_variant{})
+    {
+    }
+
     UiaVariant::UiaVariant(const VARIANT& variant):
         UiaTypeBase(std::make_shared<wil::unique_variant>(CopyToUniqueVariant(variant)))
     {
@@ -1976,6 +1987,8 @@ namespace UiaOperationAbstraction
 
         switch (lhsLocal->vt)
         {
+        case VT_EMPTY:
+            return true;
         case VT_BOOL:
             return lhsLocal->boolVal == rhsLocal->boolVal;
         case VT_I4:

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1903,7 +1903,7 @@ namespace UiaOperationAbstraction
         }
 
         template <unsigned int I>
-        void SetAt(TupleItemWrapperType<I> item)
+        void Set(TupleItemWrapperType<I> item)
         {
             if (ShouldUseRemoteApi())
             {
@@ -1919,7 +1919,7 @@ namespace UiaOperationAbstraction
         }
 
         template <unsigned int I>
-        TupleItemWrapperType<I> GetAt()
+        TupleItemWrapperType<I> Get()
         {
             if (ShouldUseRemoteApi())
             {
@@ -1945,7 +1945,7 @@ namespace UiaOperationAbstraction
         template<std::size_t I, class ItemWrapperType, class... ItemWrapperTypes>
         void SetTupleWrapperItems(ItemWrapperType&& item, ItemWrapperTypes&&... items)
         {
-            SetAt<I>(std::forward<ItemWrapperType>(item));
+            Set<I>(std::forward<ItemWrapperType>(item));
             SetTupleWrapperItems<I + 1>(std::forward<ItemWrapperTypes>(items)...);
         }
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -2000,12 +2000,12 @@ namespace UiaOperationAbstraction
             else
             {
                 // For local contexts, just set the values of the underlying `std::tuple`.
-                SetTupleWrapperItems<0>(std::forward<ItemWrapperTypes>(items)...);
+                SetTupleWrapperItems<0 /* I */>(std::forward<ItemWrapperTypes>(items)...);
             }
         }
 
         // The functions allow callers to swap all `UiaTuple` values with new, provided values by
-        // calling `Set<I>(newValue)` for every indexed value field of `UiaTuple`.
+        // calling `Set<I>(newValue)` for every indexed value/field of `UiaTuple`.
         template<std::size_t I, class ItemWrapperType, class... ItemWrapperTypes>
         void SetTupleWrapperItems(ItemWrapperType&& item, ItemWrapperTypes&&... items)
         {


### PR DESCRIPTION
## Background

Currently, UIA operation abstraction and its wrappers give access to:
1. Primitive types (`int`, `bool`, `uint`, `double`, character, ...),
2. Variants,
3. Enums (`COM`, `WinRT`),
4. UIA types (element, patterns, rectangle...),
5. Strings,
6. Some collections (arrays, maps from string to other types).

The library does not provide support for any `struct`-like types. The closest it gets to that is through collections of variants.

This change attempts to add support for `UiaTuple` to mimic C++'s `std::tuple` and to provide more tools to work with types that provide access to multiple fields of different value types.

## Changes
First and foremost, the change adds `UiaTuple` to the collection of types that the library offers. As with other wrappers, the class is a variant of two types:
1. Local, which is `std::shared_ptr<std::tuple<LocalTypes...>>`
2. Remote, which is `AutomationRemoteArray` (as it is the case for `UiaArray`).

The class offers functionalities specific to `std::tuple` such as:
1. Strongly typed `Set` by the statically provided index of the field to access and set,
2. Strongly typed `Get` by the statically provided index of the field to access and return,
3. Comparison operators (`==` and `!=`),
4. Construction out of local types (similar to `UiaInt value{ 0 }`),
5. Construction out of wrapper types for convenience to enable constructs like `UiaTuple<UiaElement, UiaRange> elementRange{ uiaElement, uiaRange }`.

**Note:** Right now, `UiaTuple` does not implement `Stringify`.

The change adds a set of tests to cover basic usage and functionalities for `UiaTuple`, which include:
1. Constructing instance of the class in different ways (default, with local values or by passing abstraction wrappers),
2. Getting and setting values for the tuples,
3. Using `UiaTuple` objects as values of collections.

In addition to that, the change adds support for "empty" `UiaVariant` values to enable default initialization of variant wrappers.

**Note:** Some tests intentionally use wrapper methods instead of local type methods (for instance `UiaStringMap` methods over `std::map` methods) even after resolving **Remote Operation** results to force the compiler to generate and analyze abstraction wrapper methods and check their correctness (since the code is template-based and therefore require usage to be instantiated and compiled).

Fixes #44