### PR TITLE
Fix navigation method missing nullity check before using cache request

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -356,18 +356,18 @@ namespace UiaOperationAbstractionTests
 
             UiaArray<UiaElement> parentChain;
             scope.While(
-            [&]() // condition
-            {
-                return !element.IsNull();
-            },
-            [&]()
-            {
-                parentChain.Append(element);
-                // The last element we get should be Null here, we are testing wrapper implementation
-                // could make sure the whole operation won't abort due to this.
-                UiaElement parent = element.GetParentElement(cacheRequest);
-                element = parent;
-            });
+                [&]() // condition
+                {
+                    return !element.IsNull();
+                },
+                [&]() // body
+                {
+                    parentChain.Append(element);
+                    // The last element we get should be Null here, we are testing wrapper implementation
+                    // could make sure the whole operation won't abort due to this.
+                    UiaElement parent = element.GetParentElement(cacheRequest);
+                    element = parent;
+                });
 
             scope.BindResult(parentChain);
             scope.Resolve();

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -339,6 +339,17 @@ namespace UiaOperationAbstractionTests
         // boundary element which means the navigation API does not
         // find the desired element. In this case, we should simply
         // return an empty element even a cache request is provided.
+        // This test is only targeted for scenario with remote operation
+        // enabled, the reason is that GetParentElement API works
+        // differently in local context and remote context. Specifically,
+        // with remote operation enable, the API will only work within
+        // single connection, if the parent element is in a different
+        // process, then remote operation will not be able to find and
+        // return it, by design we are able to get the ancestor chain
+        // until the root node of test app everytime using remote operation,
+        // but it is not fully prediactable using local API context.
+        // Also, this tests aims to provide test coverage for code path
+        // running in remote context only in wrapper implementation with.
         TEST_METHOD(CacheRequestNavigationNullReturnRemoteTest)
         {
             ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
@@ -7008,7 +7008,10 @@
             auto element = std::get<AutomationRemoteElement>(m_member).GetParentElement();
             if (cacheRequest)
             {
-                element.PopulateCache(*cacheRequest);
+                delegator->If(element.IsNull().BoolNot(), [&]()
+                {
+                    element.PopulateCache(*cacheRequest);
+                });
             }
             return element;
         }
@@ -7040,7 +7043,10 @@
             auto element = std::get<AutomationRemoteElement>(m_member).GetFirstChildElement();
             if (cacheRequest)
             {
-                element.PopulateCache(*cacheRequest);
+                delegator->If(element.IsNull().BoolNot(), [&]()
+                {
+                    element.PopulateCache(*cacheRequest);
+                });
             }
             return element;
         }
@@ -7072,7 +7078,10 @@
             auto element = std::get<AutomationRemoteElement>(m_member).GetLastChildElement();
             if (cacheRequest)
             {
-                element.PopulateCache(*cacheRequest);
+                delegator->If(element.IsNull().BoolNot(), [&]()
+                {
+                    element.PopulateCache(*cacheRequest);
+                });
             }
             return element;
         }
@@ -7104,7 +7113,10 @@
             auto element = std::get<AutomationRemoteElement>(m_member).GetNextSiblingElement();
             if (cacheRequest)
             {
-                element.PopulateCache(*cacheRequest);
+                delegator->If(element.IsNull().BoolNot(), [&]()
+                {
+                    element.PopulateCache(*cacheRequest);
+                });
             }
             return element;
         }
@@ -7136,7 +7148,10 @@
             auto element = std::get<AutomationRemoteElement>(m_member).GetPreviousSiblingElement();
             if (cacheRequest)
             {
-                element.PopulateCache(*cacheRequest);
+                delegator->If(element.IsNull().BoolNot(), [&]()
+                {
+                    element.PopulateCache(*cacheRequest);
+                });
             }
             return element;
         }


### PR DESCRIPTION
The remote operation abstraction wrapper has various navigation methods which are implemented with two steps, first these navigation methods will perform navigation operation, such _GetParentElement_, _GetNextSiblingElement_, next, the returned element is directly used to populate cache when a cache request is passed in. But between first step and second step, the implementation fails to check if the returned element is null or not, which could result in the unexpected failure when the  remote operation is operated on the provider side, this PR fixes this issue by adding nullity check in these functions.

Fixes #51