### PR TITLE
Put safe array utilities under their own namespace

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -10,6 +10,7 @@
 #include "UiaOperationAbstraction.h"
 
 using namespace UiaOperationAbstraction;
+using namespace SafeArrayUtil;
 
 // Test framework extensions used for comparing and printing different types via the
 // `Assert` test functions.

--- a/src/UIAutomation/FunctionalTests/pch.h
+++ b/src/UIAutomation/FunctionalTests/pch.h
@@ -14,11 +14,13 @@
 #include <Windows.h>
 #include <uiautomation.h>
 
+#include <sstream>
+#include <string>
+#include <variant>
+
 #include <wil/resource.h>
 #include <wil/result.h>
 #include <wil/com.h>
 
 #include <winrt/Windows.Foundation.h>
-
-#include <string>
-#include <sstream>
+#include <winrt/windows.foundation.collections.h>

--- a/src/UIAutomation/UiaOperationAbstraction/SafeArrayUtil.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/SafeArrayUtil.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "SafeArrayUtil.h"
+
+namespace SafeArrayUtil
+{
+
+HRESULT SafeArrayGetCount(_In_ SAFEARRAY* array, _Out_ long* size) noexcept try
+{
+    *size = 0;
+
+    long lowerBound = 0;
+    long upperBound = 0;
+    THROW_IF_FAILED(::SafeArrayGetLBound(array, 1 /* nDim */, &lowerBound));
+    THROW_IF_FAILED(::SafeArrayGetUBound(array, 1 /* nDim */, &upperBound));
+
+    *size = (upperBound - lowerBound + 1);
+    return S_OK;
+}
+CATCH_RETURN();
+
+} // SafeArrayUtil

--- a/src/UIAutomation/UiaOperationAbstraction/SafeArrayUtil.h
+++ b/src/UIAutomation/UiaOperationAbstraction/SafeArrayUtil.h
@@ -2,14 +2,8 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include <wil/resource.h>
-#include <wil/result.h>
-
-// --------------------------------------------------------------------------
-//
-//  SafeArray utilities
-//
-// --------------------------------------------------------------------------
+namespace SafeArrayUtil
+{
 
 // A `unique_any` alias that handles safely disposing of a SAFEARRAY.
 using unique_safearray = wil::unique_any<SAFEARRAY*, decltype(&::SafeArrayDestroy), ::SafeArrayDestroy>;
@@ -274,7 +268,7 @@ HRESULT ArrayToSafeArray(_In_ const T* originalArray, int count, _Outptr_ SAFEAR
 {
     *resultOut = nullptr;
     *resultOut = ArrayToSafeArray<vt>(originalArray, count, [](const auto& el) { return el; }).release();
-    
+
     return S_OK;
 }
 CATCH_RETURN();
@@ -346,17 +340,6 @@ HRESULT SafeArrayCompare(_In_ SAFEARRAY* array1, _In_ SAFEARRAY* array2, VARTYPE
 }
 CATCH_RETURN();
 
-inline
-HRESULT SafeArrayGetCount(_In_ SAFEARRAY* array, _Out_ long* size) noexcept try
-{
-    *size = 0;
+HRESULT SafeArrayGetCount(_In_ SAFEARRAY* array, _Out_ long* size) noexcept;
 
-    long lowerBound = 0;
-    long upperBound = 0;
-    THROW_IF_FAILED(::SafeArrayGetLBound(array, 1 /* nDim */, &lowerBound));
-    THROW_IF_FAILED(::SafeArrayGetUBound(array, 1 /* nDim */, &upperBound));
-
-    *size = (upperBound - lowerBound + 1);
-    return S_OK;
-}
-CATCH_RETURN();
+} // SafeArrayUtil

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -7,6 +7,7 @@
 using namespace winrt::Microsoft::UI::UIAutomation;
 using namespace winrt::Windows::UI::UIAutomation;
 using namespace UiaOperationAbstraction::impl;
+using namespace SafeArrayUtil;
 
 namespace winrt
 {

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -3,21 +3,7 @@
 
 #pragma once
 
-#include <variant>
-#include <memory>
-#include <optional>
-#include <functional>
-#include <sstream>
-
-#include <combaseapi.h>
-#include <UIAutomation.h>
-#include "fibersapi.h"
-
-#include <wil/Resource.h>
-#include <wil/com.h>
 #include <winrt/Microsoft.UI.UIAutomation.h>
-#include <winrt/windows.foundation.h>
-#include <winrt/windows.foundation.collections.h>
 
 #include "SafeArrayUtil.h"
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.vcxproj
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.vcxproj
@@ -165,6 +165,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="SafeArrayUtil.cpp" />
     <ClCompile Include="UiaOperationAbstraction.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/UIAutomation/UiaOperationAbstraction/pch.h
+++ b/src/UIAutomation/UiaOperationAbstraction/pch.h
@@ -6,3 +6,20 @@
 #include <unknwn.h>
 #include <Windows.h>
 #include <UIAutomation.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <variant>
+#include <vector>
+
+#include <combaseapi.h>
+#include <fibersapi.h>
+
+#include <winrt/windows.foundation.h>
+#include <winrt/windows.foundation.collections.h>
+
+#include <wil/com.h>
+#include <wil/resource.h>
+#include <wil/result.h>


### PR DESCRIPTION
This was causing name collision issues when ingesting this into the OS
repo. Effectively, we probably shouldn't be exposing internal utilities
of this library into the root namespace.

This change also includes creating a basic SafeArrayUtil.cpp and
adding more things to the pch.