### PR TITLE
Self-contain `UiaOperationAbstraction.h` for easier consumption

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -8,6 +8,7 @@
 #include "TestUtils.h"
 
 #include "UiaOperationAbstraction.h"
+#include "SafeArrayUtil.h"
 
 using namespace UiaOperationAbstraction;
 using namespace SafeArrayUtil;

--- a/src/UIAutomation/FunctionalTests/pch.h
+++ b/src/UIAutomation/FunctionalTests/pch.h
@@ -23,4 +23,3 @@
 #include <wil/com.h>
 
 #include <winrt/Windows.Foundation.h>
-#include <winrt/windows.foundation.collections.h>

--- a/src/UIAutomation/UiaOperationAbstraction/SafeArrayUtil.h
+++ b/src/UIAutomation/UiaOperationAbstraction/SafeArrayUtil.h
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include <memory>
+#include <vector>
+
+#include <wil/resource.h>
+
 namespace SafeArrayUtil
 {
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
 #include "pch.h"
+
 #include "UiaOperationAbstraction.h"
+#include "SafeArrayUtil.h"
 
 using namespace winrt::Microsoft::UI::UIAutomation;
 using namespace winrt::Windows::UI::UIAutomation;

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -3,9 +3,22 @@
 
 #pragma once
 
-#include <winrt/Microsoft.UI.UIAutomation.h>
+#include <variant>
+#include <memory>
+#include <optional>
+#include <functional>
+#include <sstream>
 
-#include "SafeArrayUtil.h"
+#include <combaseapi.h>
+#include <UIAutomation.h>
+#include <fibersapi.h>
+
+#include <wil/resource.h>
+#include <wil/com.h>
+
+#include <winrt/Microsoft.UI.UIAutomation.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 
 // Implements an API that allows users to write code that can execute either in a UIAutomation Remote Operation or
 // in the classic UIA approach where each call is a cross-process call.

--- a/src/UIAutomation/UiaOperationAbstraction/pch.h
+++ b/src/UIAutomation/UiaOperationAbstraction/pch.h
@@ -6,20 +6,3 @@
 #include <unknwn.h>
 #include <Windows.h>
 #include <UIAutomation.h>
-
-#include <functional>
-#include <memory>
-#include <optional>
-#include <sstream>
-#include <variant>
-#include <vector>
-
-#include <combaseapi.h>
-#include <fibersapi.h>
-
-#include <winrt/windows.foundation.h>
-#include <winrt/windows.foundation.collections.h>
-
-#include <wil/com.h>
-#include <wil/resource.h>
-#include <wil/result.h>


### PR DESCRIPTION
The change reorganizes some of `#include`s in `/src/UIAutomation/UiaOperationAbstraction` to self-contain `UiaOperationAbstraction.h` and allow consuming the header without including other headers.

Similar efforts have been made around `SafeArrayUtil.h`.

Fixes #53