### PR TITLE
Client Builder APIs for Extensibility work

### DIFF
--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -10,6 +10,14 @@ namespace Microsoft.UI.UIAutomation
 
     runtimeclass AutomationRemoteAnyObject;
 
+    runtimeclass AutomationRemoteGuid;
+
+    unsealed runtimeclass AutomationRemoteExtensionTarget : AutomationRemoteObject
+    {
+        void CallExtension(AutomationRemoteGuid extensionId, AutomationRemoteObject[] operands);
+        AutomationRemoteBool IsExtensionSupported(AutomationRemoteGuid extensionId);
+    }
+
     runtimeclass AutomationRemoteBool : AutomationRemoteObject
     {
         void Set(AutomationRemoteBool rhs);
@@ -196,7 +204,7 @@ namespace Microsoft.UI.UIAutomation
         void AddPattern(AutomationRemotePatternId patternId);
     }
 
-    partial runtimeclass AutomationRemoteElement : AutomationRemoteObject
+    partial runtimeclass AutomationRemoteElement : AutomationRemoteExtensionTarget
     {
         void Set(AutomationRemoteElement rhs);
 
@@ -1273,7 +1281,7 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteArray GetColumnHeaderItems();
     };
 
-    runtimeclass AutomationRemoteTextRange : AutomationRemoteObject
+    runtimeclass AutomationRemoteTextRange : AutomationRemoteExtensionTarget
     {
         void Set(AutomationRemoteTextRange rhs);
         AutomationRemoteTextRange Clone();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -10,14 +10,6 @@ namespace Microsoft.UI.UIAutomation
 
     runtimeclass AutomationRemoteAnyObject;
 
-    runtimeclass AutomationRemoteGuid;
-
-    unsealed runtimeclass AutomationRemoteExtensionTarget : AutomationRemoteObject
-    {
-        void CallExtension(AutomationRemoteGuid extensionId, AutomationRemoteObject[] operands);
-        AutomationRemoteBool IsExtensionSupported(AutomationRemoteGuid extensionId);
-    }
-
     runtimeclass AutomationRemoteBool : AutomationRemoteObject
     {
         void Set(AutomationRemoteBool rhs);
@@ -147,6 +139,12 @@ namespace Microsoft.UI.UIAutomation
 
         AutomationRemoteAnnotationType LookupAnnotationType();
         AutomationRemotePropertyId LookupPropertyId();
+    }
+
+    unsealed runtimeclass AutomationRemoteExtensionTarget : AutomationRemoteObject
+    {
+        void CallExtension(AutomationRemoteGuid extensionId, AutomationRemoteObject[] operands);
+        AutomationRemoteBool IsExtensionSupported(AutomationRemoteGuid extensionId);
     }
 
     runtimeclass AutomationRemoteArray : AutomationRemoteObject

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
@@ -491,6 +491,24 @@ void RemoteOperationInstructionSerializer::Write(const bytecode::Stringify& inst
     Write(instruction.targetId);
 }
 
+void RemoteOperationInstructionSerializer::Write(const bytecode::CallExtension& instruction)
+{
+    Write(instruction.targetId);
+    Write(instruction.extensionIdId);
+    Write(static_cast<int>(instruction.operandIds.size()));
+    for (const auto& operandId : instruction.operandIds)
+    {
+        Write(operandId);
+    }
+}
+
+void RemoteOperationInstructionSerializer::Write(const bytecode::IsExtensionSupported& instruction)
+{
+    Write(instruction.resultId);
+    Write(instruction.targetId);
+    Write(instruction.extensionIdId);
+}
+
 void RemoteOperationInstructionSerializer::Write(const GetterBase& instruction)
 {
     Write(instruction.resultId);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.h
@@ -114,6 +114,8 @@ private:
     void Write(const bytecode::LookupId&);
     void Write(const bytecode::LookupGuid&);
     void Write(const bytecode::Stringify&);
+    void Write(const bytecode::CallExtension&);
+    void Write(const bytecode::IsExtensionSupported&);
 
     void Write(const bytecode::GetterBase&);
 #include "RemoteOperationInstructionSerializerMethods.g.h"

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructions.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructions.h
@@ -152,6 +152,10 @@ enum class InstructionType
     Stringify = 0x51,
     GetMetadataValue = 0x52,
 
+    // Extensibility
+    CallExtension = 0x53,
+    IsExtensionSupported = 0x54,
+
     // UIA pattern getters and pattern methods
 #include "RemoteOperationInstructionEnumValues.g.h"
 };
@@ -242,6 +246,8 @@ constexpr std::array c_supportedInstructions =
     InstructionType::PopulateCache,
     InstructionType::Stringify,
     InstructionType::GetMetadataValue,
+    InstructionType::CallExtension,
+    InstructionType::IsExtensionSupported,
 
     // Auto-generated UIA pattern getters and pattern methods
 #include "RemoteOperationInstructionEnumValuesArray.g.h"
@@ -933,6 +939,24 @@ struct GetMetadataValue
     OperandId metadataId;
 };
 
+struct CallExtension
+{
+    constexpr static InstructionType type = InstructionType::CallExtension;
+
+    OperandId targetId;
+    OperandId extensionIdId;
+    std::vector<OperandId> operandIds;
+};
+
+struct IsExtensionSupported
+{
+    constexpr static InstructionType type = InstructionType::IsExtensionSupported;
+
+    OperandId resultId;
+    OperandId targetId;
+    OperandId extensionIdId;
+};
+
 #include "RemoteOperationInstructions.g.h"
 
 using Instruction = std::variant<
@@ -1051,7 +1075,11 @@ using Instruction = std::variant<
     IsGuid,
     IsCacheRequest,
 
-    Stringify
+    Stringify,
+
+    // Provider Extension methods
+    CallExtension,
+    IsExtensionSupported
 
 #include "RemoteOperationInstructionsVariantParams.g.h"
     >;

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -510,6 +510,41 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return result;
     }
 
+    // AutomationRemoteExtensionTarget
+
+    AutomationRemoteExtensionTarget::AutomationRemoteExtensionTarget(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
+        : base_type(operandId, parent)
+    {
+    }
+
+    void AutomationRemoteExtensionTarget::CallExtension(const winrt::AutomationRemoteGuid& extensionId, winrt::array_view<const winrt::AutomationRemoteObject> operands)
+    {
+        std::vector<bytecode::OperandId> operandIds;
+        for (const auto& operand : operands)
+        {
+            operandIds.emplace_back(GetOperandId<AutomationRemoteObject>(operand));
+        }
+
+        m_parent->InsertInstruction(bytecode::CallExtension{
+            m_operandId,
+            GetOperandId<AutomationRemoteGuid>(extensionId),
+            std::move(operandIds)
+            });
+    }
+
+    winrt::AutomationRemoteBool AutomationRemoteExtensionTarget::IsExtensionSupported(const winrt::AutomationRemoteGuid& extensionId)
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::IsExtensionSupported{
+            resultId,
+            m_operandId,
+            GetOperandId<AutomationRemoteGuid>(extensionId)
+            });
+
+        const auto result = Make<AutomationRemoteBool>(resultId);
+        return result;
+    }
+
     // AutomationRemoteStringMap
 
     AutomationRemoteStringMap::AutomationRemoteStringMap(bytecode::OperandId operandId, AutomationRemoteOperation& parent) :

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -539,7 +539,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
             resultId,
             m_operandId,
             GetOperandId<AutomationRemoteGuid>(extensionId)
-            });
+        });
 
         const auto result = Make<AutomationRemoteBool>(resultId);
         return result;

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.g.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.g.h
@@ -568,7 +568,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteSupportedTextSelection GetSupportedTextSelection();
     };
 
-    class AutomationRemoteTextRange : public AutomationRemoteTextRangeT<AutomationRemoteTextRange, AutomationRemoteObject>
+    class AutomationRemoteTextRange : public AutomationRemoteTextRangeT<AutomationRemoteTextRange, AutomationRemoteExtensionTarget>
     {
     public:
         AutomationRemoteTextRange(bytecode::OperandId operandId, AutomationRemoteOperation& parent);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -18,9 +18,11 @@
 #include "AutomationRemoteCacheRequest.g.h"
 #include "AutomationRemoteElement.g.h"
 #include "AutomationRemoteAnyObject.g.h"
+#include "AutomationRemoteExtensionTarget.g.h"
 #include "AutomationRemoteOperation.h"
 
 #include "RemoteOperationInstructions.h"
+#include <winrt/Windows.Foundation.Collections.h>
 
 namespace winrt
 {
@@ -521,6 +523,15 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteString Stringify();
     };
 
+     class AutomationRemoteExtensionTarget : public AutomationRemoteExtensionTargetT<AutomationRemoteExtensionTarget, AutomationRemoteObject>
+    {
+    public:
+        AutomationRemoteExtensionTarget(bytecode::OperandId operandId, AutomationRemoteOperation& parent);
+
+        void CallExtension(const winrt::AutomationRemoteGuid& extensionId, winrt::array_view<const winrt::AutomationRemoteObject> operands);
+        winrt::AutomationRemoteBool IsExtensionSupported(const winrt::AutomationRemoteGuid& extensionId);
+    };
+
     struct AutomationRemoteStringMap : AutomationRemoteStringMapT<AutomationRemoteStringMap, Microsoft::UI::UIAutomation::implementation::AutomationRemoteObject>
     {
         AutomationRemoteStringMap(bytecode::OperandId operandId, AutomationRemoteOperation& parent);
@@ -547,7 +558,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         void AddPattern(const winrt::AutomationRemotePatternId& patternId);
     };
 
-    class AutomationRemoteElement : public AutomationRemoteElementT<AutomationRemoteElement, AutomationRemoteObject>
+    class AutomationRemoteElement : public AutomationRemoteElementT<AutomationRemoteElement, AutomationRemoteExtensionTarget>
     {
     public:
         AutomationRemoteElement(bytecode::OperandId operandId, AutomationRemoteOperation& parent);


### PR DESCRIPTION
This PR adds client builder apis for the Extensibility work that is introduced recently. Adds Builder APIs for two functionalities CallExtension and IsExtensionSupported. These methods are added to a new class AutomationRemoteExtensionTarget which is extended by AutomationRemoteElement and AutomationRemoteTextRange respectively.