### PR TITLE
ConnectionBoundObject wrapper API

### DIFF
--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteAnyObjectMethods.g.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteAnyObjectMethods.g.h
@@ -36,7 +36,6 @@
         winrt::AutomationRemoteTextPattern AsTextPattern();
         winrt::AutomationRemoteBool IsTextRange();
         winrt::AutomationRemoteTextRange AsTextRange();
-        winrt::AutomationRemoteBool IsConnectionBoundObject();
         winrt::AutomationRemoteConnectionBoundObject AsConnectionBoundObject();
         winrt::AutomationRemoteBool IsTogglePattern();
         winrt::AutomationRemoteTogglePattern AsTogglePattern();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteAnyObjectMethods.g.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteAnyObjectMethods.g.h
@@ -36,6 +36,8 @@
         winrt::AutomationRemoteTextPattern AsTextPattern();
         winrt::AutomationRemoteBool IsTextRange();
         winrt::AutomationRemoteTextRange AsTextRange();
+        winrt::AutomationRemoteBool IsConnectionBoundObject();
+        winrt::AutomationRemoteConnectionBoundObject AsConnectionBoundObject();
         winrt::AutomationRemoteBool IsTogglePattern();
         winrt::AutomationRemoteTogglePattern AsTogglePattern();
         winrt::AutomationRemoteBool IsTransformPattern();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.cpp
@@ -154,6 +154,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
 
     // NewEmpty is similar to NewNull except it doesn't insert any instruction, instead NewEmpty serves as a place holder
     // for any operands that are to be set when the Remote Operation gets executed(an out only parameter without wasting an instruction)
+    // This is particularly used with CallExtension as it takes an arrray of operands and most of them will be
+    // out params and using NullOperand for all of them would waste instructions.
     winrt::AutomationRemoteAnyObject AutomationRemoteOperation::NewEmpty()
     {
         const auto newId = GetNextId();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.cpp
@@ -152,6 +152,15 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return make<AutomationRemoteAnyObject>(newId, *this);
     }
 
+    winrt::AutomationRemoteAnyObject AutomationRemoteOperation::NewEmpty()
+    {
+        // NewEmpty is similar to NewNull except it doesn't insert any instruction, instead NewEmpty serves as a place holder
+        // for any operands that are to be set when the Remote Operation gets executed(an out only parameter without wasting an instruction)
+        const auto newId = GetNextId();
+
+        return make<AutomationRemoteAnyObject>(newId, *this);
+    }
+
     winrt::AutomationRemoteElement AutomationRemoteOperation::ImportElement(winrt::AutomationElement const& element)
     {
         const auto elementId = GetNextId();
@@ -167,6 +176,15 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         m_remoteOperation.ImportTextRange({ textRangeId.Value }, textRange);
 
         const auto result = make<AutomationRemoteTextRange>(textRangeId, *this);
+        return result;
+    }
+
+    winrt::AutomationRemoteConnectionBoundObject AutomationRemoteOperation::ImportConnectionBoundObject(winrt::AutomationConnectionBoundObject const& connectionBoundObject)
+    {
+        const auto connectionBoundObjectId = GetNextId();
+        m_remoteOperation.ImportConnectionBoundObject({ connectionBoundObjectId.Value }, connectionBoundObject);
+
+        const auto result = make<AutomationRemoteConnectionBoundObject>(connectionBoundObjectId, *this);
         return result;
     }
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.cpp
@@ -152,10 +152,10 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return make<AutomationRemoteAnyObject>(newId, *this);
     }
 
+    // NewEmpty is similar to NewNull except it doesn't insert any instruction, instead NewEmpty serves as a place holder
+    // for any operands that are to be set when the Remote Operation gets executed(an out only parameter without wasting an instruction)
     winrt::AutomationRemoteAnyObject AutomationRemoteOperation::NewEmpty()
     {
-        // NewEmpty is similar to NewNull except it doesn't insert any instruction, instead NewEmpty serves as a place holder
-        // for any operands that are to be set when the Remote Operation gets executed(an out only parameter without wasting an instruction)
         const auto newId = GetNextId();
 
         return make<AutomationRemoteAnyObject>(newId, *this);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.h
@@ -66,9 +66,11 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteArray NewArray();
         winrt::AutomationRemoteStringMap NewStringMap();
         winrt::AutomationRemoteAnyObject NewNull();
+         winrt::AutomationRemoteAnyObject NewEmpty();
 
         winrt::AutomationRemoteElement ImportElement(winrt::Windows::UI::UIAutomation::AutomationElement const& element);
         winrt::AutomationRemoteTextRange ImportTextRange(winrt::Windows::UI::UIAutomation::AutomationTextRange const& textRange);
+        winrt::AutomationRemoteConnectionBoundObject ImportConnectionBoundObject(winrt::Windows::UI::UIAutomation::AutomationConnectionBoundObject const& connectionBoundObject);
 
         AutomationRemoteOperationResponseToken RequestResponse(const winrt::AutomationRemoteObject& object);
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
@@ -3283,11 +3283,6 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return As<AutomationRemoteTextRange>();
     }
 
-    winrt::AutomationRemoteBool AutomationRemoteAnyObject::IsConnectionBoundObject()
-    {
-        throw hresult_not_implemented();
-    }
-
     winrt::AutomationRemoteConnectionBoundObject AutomationRemoteAnyObject::AsConnectionBoundObject()
     {
         return As<AutomationRemoteConnectionBoundObject>();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
@@ -3283,6 +3283,16 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return As<AutomationRemoteTextRange>();
     }
 
+    winrt::AutomationRemoteBool AutomationRemoteAnyObject::IsConnectionBoundObject()
+    {
+        throw hresult_not_implemented();
+    }
+
+    winrt::AutomationRemoteConnectionBoundObject AutomationRemoteAnyObject::AsConnectionBoundObject()
+    {
+        return As<AutomationRemoteConnectionBoundObject>();
+    }
+
     winrt::AutomationRemoteBool AutomationRemoteAnyObject::IsTogglePattern()
     {
         throw hresult_not_implemented();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -1593,6 +1593,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteTextPattern AsTextPattern();
         AutomationRemoteBool IsTextRange();
         AutomationRemoteTextRange AsTextRange();
+        AutomationRemoteConnectionBoundObject AsConnectionBoundObject();
+        AutomationRemoteBool IsConnectionBoundObject();
         AutomationRemoteBool IsTogglePattern();
         AutomationRemoteTogglePattern AsTogglePattern();
         AutomationRemoteBool IsTransformPattern();
@@ -1759,9 +1761,11 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteArray NewArray();
         AutomationRemoteStringMap NewStringMap();
         AutomationRemoteAnyObject NewNull();
+        AutomationRemoteAnyObject NewEmpty();
 
         AutomationRemoteElement ImportElement(Windows.UI.UIAutomation.AutomationElement element);
         AutomationRemoteTextRange ImportTextRange(Windows.UI.UIAutomation.AutomationTextRange textRange);
+        AutomationRemoteConnectionBoundObject ImportConnectionBoundObject(Windows.UI.UIAutomation.AutomationConnectionBoundObject connectionBoundObject);
 
         AutomationRemoteOperationResponseToken RequestResponse(AutomationRemoteObject object);
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -1599,7 +1599,6 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteBool IsTextRange();
         AutomationRemoteTextRange AsTextRange();
         AutomationRemoteConnectionBoundObject AsConnectionBoundObject();
-        AutomationRemoteBool IsConnectionBoundObject();
         AutomationRemoteBool IsTogglePattern();
         AutomationRemoteTogglePattern AsTogglePattern();
         AutomationRemoteBool IsTransformPattern();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -1303,6 +1303,11 @@ namespace Microsoft.UI.UIAutomation
         void ShowContextMenu();
     };
 
+    runtimeclass AutomationRemoteConnectionBoundObject : AutomationRemoteExtensionTarget
+    {
+        void Set(AutomationRemoteConnectionBoundObject rhs);
+    }
+
     runtimeclass AutomationRemoteTextPattern : AutomationRemoteObject
     {
         void Set(AutomationRemoteTextPattern rhs);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -730,6 +730,13 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         });
     }
 
+    // AutomationRemoteConnectionBoundObject
+    
+     AutomationRemoteConnectionBoundObject::AutomationRemoteConnectionBoundObject(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
+        : base_type(operandId, parent)
+    {
+    }
+
     // AutomationRemoteAnyObject
 
     AutomationRemoteAnyObject::AutomationRemoteAnyObject(bytecode::OperandId operandId, AutomationRemoteOperation& parent)

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -17,6 +17,7 @@
 #include "AutomationRemoteStringMap.g.h"
 #include "AutomationRemoteCacheRequest.g.h"
 #include "AutomationRemoteElement.g.h"
+#include "AutomationRemoteConnectionBoundObject.g.h"
 #include "AutomationRemoteAnyObject.g.h"
 #include "AutomationRemoteExtensionTarget.g.h"
 #include "AutomationRemoteOperation.h"
@@ -593,6 +594,17 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteElement Navigate(const winrt::AutomationRemoteInt& direction);
         winrt::AutomationRemoteElement Navigate(NavigateDirection direction);
     };
+
+    class AutomationRemoteConnectionBoundObject : public AutomationRemoteConnectionBoundObjectT<AutomationRemoteConnectionBoundObject, AutomationRemoteExtensionTarget>
+    {
+        public:
+            AutomationRemoteConnectionBoundObject(bytecode::OperandId operandId, AutomationRemoteOperation& parent);
+
+            void Set(const class_type& rhs)
+            {
+                AutomationRemoteObject::Set<AutomationRemoteConnectionBoundObject>(rhs);
+            }
+    }
 
     class AutomationRemoteAnyObject : public AutomationRemoteAnyObjectT<AutomationRemoteAnyObject, AutomationRemoteObject>
     {


### PR DESCRIPTION
This PR implements the wrapper API for ConnectionBoundObject implemented as part of Custom Pattern Extensibility work. A new API called NewEmpty is also introduced to create a stand in for an empty object. this is similar to NewNull, except the NewEmpty doesn't insert any instruction, but acts as a place holder for the new operands to be assigned when the Remote Operation is executed. In other words, it acts as an out only param.