### PR TITLE
Update enum and metadata wrapper

### DIFF
--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -1946,6 +1946,21 @@ namespace UiaOperationAbstraction
         ToRemote();
     }
 
+    UiaBool UiaVariant::IsNull() const
+    {
+        if (ShouldUseRemoteApi())
+        {
+            auto remoteValue = std::get_if<RemoteType>(&m_member);
+            if (remoteValue)
+            {
+                return remoteValue->IsNull();
+            }
+        }
+
+        // The local version of a UiaVariant can never be null.
+        return false;
+    }
+
     UiaBool UiaVariant::operator==(const UiaVariant& rhs)
     {
         if (ShouldUseRemoteApi())

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -29,6 +29,9 @@ namespace UiaOperationAbstraction
 {
     using unique_safearray = wil::unique_any<SAFEARRAY*, decltype(&::SafeArrayDestroy), ::SafeArrayDestroy>;
 
+    template <typename StandinT>
+    using CastFuncType = StandinT (winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::*)() const;
+
     // This function must be called before using the abstraction.
     void Initialize(bool useRemoteOperations, _In_ IUIAutomation* automation) noexcept;
 
@@ -927,11 +930,13 @@ namespace UiaOperationAbstraction
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
 
-    template <typename ComEnumT, typename WinRTEnumT, typename StandinT>
+    template <typename ComEnumT, typename WinRTEnumT, typename StandinT, CastFuncType<StandinT> CastFunc>
     class UiaEnum : public UiaTypeBase<ComEnumT, StandinT>
     {
     public:
         static constexpr VARTYPE c_comVariantType = VT_I4;
+        static constexpr auto c_variantMember = &VARIANT::lVal;
+        static constexpr auto c_anyCast = CastFunc;
 
         UiaEnum(ComEnumT value) : UiaTypeBase(value)
         {
@@ -947,7 +952,7 @@ namespace UiaOperationAbstraction
         {
         }
 
-        UiaEnum(const UiaEnum<ComEnumT, WinRTEnumT, StandinT>&) = default;
+        UiaEnum(const UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc>&) = default;
 
         operator ComEnumT() const
         {
@@ -964,7 +969,7 @@ namespace UiaOperationAbstraction
             return static_cast<WinRTEnumT>(std::get<ComEnumT>(m_member));
         }
 
-        UiaEnum<ComEnumT, WinRTEnumT, StandinT>& operator=(const UiaEnum<ComEnumT, WinRTEnumT, StandinT>& other)
+        UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc>& operator=(const UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc>& other)
         {
             if (ShouldUseRemoteApi())
             {
@@ -981,7 +986,7 @@ namespace UiaOperationAbstraction
             return *this;
         }
 
-        UiaBool operator==(const UiaEnum<ComEnumT, WinRTEnumT, StandinT>& rhs) const
+        UiaBool operator==(const UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc>& rhs) const
         {
             if (ShouldUseRemoteApi())
             {
@@ -995,7 +1000,7 @@ namespace UiaOperationAbstraction
             return std::get<ComEnumT>(m_member) == std::get<ComEnumT>(rhs.m_member);
         }
 
-        UiaBool operator!=(const UiaEnum<ComEnumT, WinRTEnumT, StandinT>& rhs) const
+        UiaBool operator!=(const UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc>& rhs) const
         {
             if (ShouldUseRemoteApi())
             {
@@ -1012,13 +1017,13 @@ namespace UiaOperationAbstraction
         template<class T>
         UiaBool operator==(T rhs) const
         {
-            return (*this == UiaEnum<ComEnumT, WinRTEnumT, StandinT>(rhs));
+            return (*this == UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc>(rhs));
         }
 
         template<class T>
         UiaBool operator!=(T rhs) const
         {
-            return (*this != UiaEnum<ComEnumT, WinRTEnumT, StandinT>(rhs));
+            return (*this != UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc>(rhs));
         }
 
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result)
@@ -1706,14 +1711,19 @@ namespace UiaOperationAbstraction
         explicit UiaVariant(UiaDouble value);
         explicit UiaVariant(UiaString value);
 
-        template <typename ComEnumT, typename WinRTEnumT, typename StandinT>
-        explicit UiaVariant(UiaEnum<ComEnumT, WinRTEnumT, StandinT> value) :
+        template <typename ComEnumT, typename WinRTEnumT, typename StandinT, CastFuncType<StandinT> CastFunc>
+        explicit UiaVariant(UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc> value) :
             UiaTypeBase(
                 value.IsRemoteType() ?
-                UiaVariant(static_cast<AutomationRemoteObject>(static_cast<typename UiaEnum<ComEnumT, WinRTEnumT, StandinT>::RemoteType>(value))) :
+                UiaVariant(static_cast<AutomationRemoteObject>(static_cast<typename UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc>::RemoteType>(value))) :
                 UiaVariant(details::MakeVariantFrom<UiaInt>(static_cast<int>(static_cast<WinRTEnumT>(value)))))
         {
         }
+
+        UiaBool IsNull() const;
+
+        UiaBool operator!() const { return IsNull(); }
+        operator UiaBool() const { return !IsNull(); }
 
         UiaVariant(const UiaVariant&) = default;
 
@@ -1775,7 +1785,7 @@ namespace UiaOperationAbstraction
             }
             auto localValue = std::get<typename LocalType>(m_member);
             THROW_HR_IF(E_INVALIDARG, V_VT(localValue) != ReturnType::c_comVariantType);
-            return (*localValue).*(ReturnType::c_variantMember);
+            return static_cast<typename ReturnType::LocalType>((*localValue).*(ReturnType::c_variantMember));
         }
 
         UiaBool IsBool() const;

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1724,7 +1724,7 @@ namespace UiaOperationAbstraction
         explicit UiaVariant(UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc> value) :
             UiaTypeBase(
                 value.IsRemoteType() ?
-                UiaVariant(static_cast<AutomationRemoteObject>(static_cast<typename UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc>::RemoteType>(value))) :
+                UiaVariant(static_cast<winrt::Microsoft::UI::UIAutomation::AutomationRemoteObject>(static_cast<typename UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc>::RemoteType>(value))) :
                 UiaVariant(details::MakeVariantFrom<UiaInt>(static_cast<int>(static_cast<WinRTEnumT>(value)))))
         {
         }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -29,6 +29,15 @@ namespace UiaOperationAbstraction
 {
     using unique_safearray = wil::unique_any<SAFEARRAY*, decltype(&::SafeArrayDestroy), ::SafeArrayDestroy>;
 
+    // This type is representing a function type, where the return type is a template parameter, the function should be
+    // a const member function of class `winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject`, the parameter
+    // list is void.
+    // For example, the type of function:
+    //     `winrt::Microsoft::UI::UIAutomation::AutomationRemoteSayAsInterpretAs winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsSayAsInterpretAs() const;`
+    // can be represented by CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteSayAsInterpretAs>.
+    // This type is used as one of the template parameters of class `UiaEnum`, for the sake of this, we could assign the
+    // any cast function for `UiaEnum`. And furthermore, we could use `UiaVariant::AsType` to convert `UiaVariant` to
+    // any `UiaEnum` classes.
     template <typename StandinT>
     using CastFuncType = StandinT (winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::*)() const;
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
@@ -2148,6 +2148,8 @@
         UiaElement GetNextSiblingElement(std::optional<UiaCacheRequest> cacheRequest = std::nullopt);
         UiaElement GetPreviousSiblingElement(std::optional<UiaCacheRequest> cacheRequest = std::nullopt);
 
+        UiaVariant GetMetadataValue(UiaPropertyId propertyId, UiaMetadata metadataId);
+
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result)
         {
             m_member = result.as<IUIAutomationElement>();

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionEnums.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionEnums.g.h
@@ -7,140 +7,210 @@
     using UiaActiveEnd = UiaEnum<
         ActiveEnd,
         winrt::Microsoft::UI::UIAutomation::AutomationActiveEnd,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteActiveEnd>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteActiveEnd,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteActiveEnd>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsActiveEnd)>;
     using UiaAnimationStyle = UiaEnum<
         AnimationStyle,
         winrt::Microsoft::UI::UIAutomation::AutomationAnimationStyle,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnimationStyle>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnimationStyle,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnimationStyle>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsAnimationStyle)>;
     using UiaAnnotationType = UiaEnum<
         int,
         winrt::Microsoft::UI::UIAutomation::AutomationAnnotationType,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnnotationType>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnnotationType,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnnotationType>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsAnnotationType)>;
     using UiaBulletStyle = UiaEnum<
         BulletStyle,
         winrt::Microsoft::UI::UIAutomation::AutomationBulletStyle,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteBulletStyle>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteBulletStyle,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteBulletStyle>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsBulletStyle)>;
     using UiaCapStyle = UiaEnum<
         CapStyle,
         winrt::Microsoft::UI::UIAutomation::AutomationCapStyle,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteCapStyle>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteCapStyle,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteCapStyle>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsCapStyle)>;
     using UiaCaretBidiMode = UiaEnum<
         CaretBidiMode,
         winrt::Microsoft::UI::UIAutomation::AutomationCaretBidiMode,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteCaretBidiMode>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteCaretBidiMode,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteCaretBidiMode>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsCaretBidiMode)>;
     using UiaCaretPosition = UiaEnum<
         CaretPosition,
         winrt::Microsoft::UI::UIAutomation::AutomationCaretPosition,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteCaretPosition>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteCaretPosition,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteCaretPosition>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsCaretPosition)>;
     using UiaControlType = UiaEnum<
         CONTROLTYPEID,
         winrt::Microsoft::UI::UIAutomation::AutomationControlType,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteControlType>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteControlType,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteControlType>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsControlType)>;
     using UiaDockPosition = UiaEnum<
         DockPosition,
         winrt::Microsoft::UI::UIAutomation::AutomationDockPosition,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteDockPosition>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteDockPosition,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteDockPosition>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsDockPosition)>;
     using UiaExpandCollapseState = UiaEnum<
         ExpandCollapseState,
         winrt::Microsoft::UI::UIAutomation::AutomationExpandCollapseState,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteExpandCollapseState>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteExpandCollapseState,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteExpandCollapseState>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsExpandCollapseState)>;
     using UiaFlowDirections = UiaEnum<
         FlowDirections,
         winrt::Microsoft::UI::UIAutomation::AutomationFlowDirections,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteFlowDirections>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteFlowDirections,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteFlowDirections>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsFlowDirections)>;
     using UiaHeadingLevel = UiaEnum<
         HEADINGLEVELID,
         winrt::Microsoft::UI::UIAutomation::AutomationHeadingLevel,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteHeadingLevel>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteHeadingLevel,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteHeadingLevel>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsHeadingLevel)>;
     using UiaHorizontalTextAlignment = UiaEnum<
         HorizontalTextAlignment,
         winrt::Microsoft::UI::UIAutomation::AutomationHorizontalTextAlignment,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteHorizontalTextAlignment>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteHorizontalTextAlignment,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteHorizontalTextAlignment>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsHorizontalTextAlignment)>;
     using UiaLandmarkType = UiaEnum<
         LANDMARKTYPEID,
         winrt::Microsoft::UI::UIAutomation::AutomationLandmarkType,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteLandmarkType>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteLandmarkType,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteLandmarkType>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsLandmarkType)>;
     using UiaLiveSetting = UiaEnum<
         LiveSetting,
         winrt::Microsoft::UI::UIAutomation::AutomationLiveSetting,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteLiveSetting>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteLiveSetting,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteLiveSetting>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsLiveSetting)>;
     using UiaMetadata = UiaEnum<
         METADATAID,
         winrt::Microsoft::UI::UIAutomation::AutomationMetadata,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteMetadata>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteMetadata,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteMetadata>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsMetadata)>;
     using UiaNavigateDirection = UiaEnum<
         NavigateDirection,
         winrt::Microsoft::UI::UIAutomation::AutomationNavigateDirection,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteNavigateDirection>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteNavigateDirection,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteNavigateDirection>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsNavigateDirection)>;
     using UiaOrientationType = UiaEnum<
         OrientationType,
         winrt::Microsoft::UI::UIAutomation::AutomationOrientationType,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteOrientationType>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteOrientationType,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteOrientationType>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsOrientationType)>;
     using UiaOutlineStyles = UiaEnum<
         OutlineStyles,
         winrt::Microsoft::UI::UIAutomation::AutomationOutlineStyles,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteOutlineStyles>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteOutlineStyles,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteOutlineStyles>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsOutlineStyles)>;
     using UiaPatternId = UiaEnum<
         PATTERNID,
         winrt::Microsoft::UI::UIAutomation::AutomationPatternId,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemotePatternId>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemotePatternId,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemotePatternId>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsPatternId)>;
     using UiaPropertyId = UiaEnum<
         PROPERTYID,
         winrt::Microsoft::UI::UIAutomation::AutomationPropertyId,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemotePropertyId>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemotePropertyId,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemotePropertyId>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsPropertyId)>;
     using UiaRowOrColumnMajor = UiaEnum<
         RowOrColumnMajor,
         winrt::Microsoft::UI::UIAutomation::AutomationRowOrColumnMajor,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteRowOrColumnMajor>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteRowOrColumnMajor,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteRowOrColumnMajor>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsRowOrColumnMajor)>;
     using UiaSayAsInterpretAs = UiaEnum<
         SayAsInterpretAs,
         winrt::Microsoft::UI::UIAutomation::AutomationSayAsInterpretAs,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteSayAsInterpretAs>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteSayAsInterpretAs,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteSayAsInterpretAs>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsSayAsInterpretAs)>;
     using UiaScrollAmount = UiaEnum<
         ScrollAmount,
         winrt::Microsoft::UI::UIAutomation::AutomationScrollAmount,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteScrollAmount>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteScrollAmount,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteScrollAmount>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsScrollAmount)>;
     using UiaStyleId = UiaEnum<
         int,
         winrt::Microsoft::UI::UIAutomation::AutomationStyleId,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteStyleId>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteStyleId,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteStyleId>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsStyleId)>;
     using UiaSupportedTextSelection = UiaEnum<
         SupportedTextSelection,
         winrt::Microsoft::UI::UIAutomation::AutomationSupportedTextSelection,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteSupportedTextSelection>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteSupportedTextSelection,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteSupportedTextSelection>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsSupportedTextSelection)>;
     using UiaSynchronizedInputType = UiaEnum<
         SynchronizedInputType,
         winrt::Microsoft::UI::UIAutomation::AutomationSynchronizedInputType,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteSynchronizedInputType>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteSynchronizedInputType,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteSynchronizedInputType>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsSynchronizedInputType)>;
     using UiaTextAttributeId = UiaEnum<
         TEXTATTRIBUTEID,
         winrt::Microsoft::UI::UIAutomation::AutomationTextAttributeId,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextAttributeId>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextAttributeId,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextAttributeId>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsTextAttributeId)>;
     using UiaTextDecorationLineStyle = UiaEnum<
         TextDecorationLineStyle,
         winrt::Microsoft::UI::UIAutomation::AutomationTextDecorationLineStyle,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextDecorationLineStyle>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextDecorationLineStyle,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextDecorationLineStyle>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsTextDecorationLineStyle)>;
     using UiaTextPatternRangeEndpoint = UiaEnum<
         TextPatternRangeEndpoint,
         winrt::Microsoft::UI::UIAutomation::AutomationTextPatternRangeEndpoint,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextPatternRangeEndpoint>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextPatternRangeEndpoint,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextPatternRangeEndpoint>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsTextPatternRangeEndpoint)>;
     using UiaTextUnit = UiaEnum<
         TextUnit,
         winrt::Microsoft::UI::UIAutomation::AutomationTextUnit,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextUnit>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextUnit,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextUnit>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsTextUnit)>;
     using UiaToggleState = UiaEnum<
         ToggleState,
         winrt::Microsoft::UI::UIAutomation::AutomationToggleState,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteToggleState>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteToggleState,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteToggleState>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsToggleState)>;
     using UiaWindowInteractionState = UiaEnum<
         WindowInteractionState,
         winrt::Microsoft::UI::UIAutomation::AutomationWindowInteractionState,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteWindowInteractionState>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteWindowInteractionState,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteWindowInteractionState>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsWindowInteractionState)>;
     using UiaWindowVisualState = UiaEnum<
         WindowVisualState,
         winrt::Microsoft::UI::UIAutomation::AutomationWindowVisualState,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteWindowVisualState>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteWindowVisualState,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteWindowVisualState>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsWindowVisualState)>;
     using UiaZoomUnit = UiaEnum<
         ZoomUnit,
         winrt::Microsoft::UI::UIAutomation::AutomationZoomUnit,
-        winrt::Microsoft::UI::UIAutomation::AutomationRemoteZoomUnit>;
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteZoomUnit,
+        static_cast<CastFuncType<winrt::Microsoft::UI::UIAutomation::AutomationRemoteZoomUnit>>(
+            &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsZoomUnit)>;

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
@@ -7173,3 +7173,28 @@
 
         return localResult;
     }
+
+    UiaVariant UiaElement::GetMetadataValue(UiaPropertyId propertyId, UiaMetadata metadataId)
+    {
+        auto delegator = UiaOperationScope::GetCurrentDelegator();
+        if (delegator && delegator->GetUseRemoteApi())
+        {
+            this->ToRemote();
+            propertyId.ToRemote();
+            metadataId.ToRemote();
+            return std::get<AutomationRemoteElement>(m_member).GetMetadataValue(
+                propertyId,
+                metadataId);
+        }
+
+        auto localObject = std::get<winrt::com_ptr<IUIAutomationElement>>(m_member);
+        auto localObjectQueried = localObject.as<IUIAutomationElement7>();
+
+        wil::unique_variant metadataValue;
+        winrt::check_hresult(localObjectQueried->GetCurrentMetadataValue(
+            propertyId,
+            metadataId,
+            &metadataValue));
+
+        return metadataValue;
+    }


### PR DESCRIPTION
The reason for making this change is to make the wrapper supports get metadata value functionality.
Therefore, a helper is added `UiaVariant GetMetadataValue(UiaPropertyId propertyId, UiaMetadata metadataId);`
Once we get the returned `UiaVariant`, the proper usage is to cast this to the exact enum type we want (for example `UiaSayAsInterpretAs`). However, this cast is not supported in the wrapper yet. Also, `UiaVariant::IsNull()` is added, otherwise cannot really use the returned value.

To address the cast issue from `UiaVariant` to `UiaEnum`, an update is made to the `UiaEnum` definition to include a `CastFunc` template parameter. The type of this function is defined as:
`StandinT (winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::*)() const`.
After adding `CastFunc`, we could assign the cast function for each `UiaEnum` class. And assign to `c_anyCast`, which will let us utilize `UiaVariant::AsType` to cast.

For example, `UiaSayAsInterpretAs` could specify the cast function as `&winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsSayAsInterpretAs` to convert a `UiaVariant` to `UiaSayAsInterpretAs`

The type definition in `UiaTypeAbstractionEnums.g.h` is updated based on template parameter change.

Note that, in the `UiaVariant::AsType` function, we have to add an extra static cast for the local value. This is not required before because the returned local type always matches the type of the local variant. But now we need this static cast to convert local variant with `VT_I4` type to a local enum type (for example `winrt::Microsoft::UI::UIAutomation::AutomationSayAsInterpretAs`).

