### PR TITLE
Target the [latest] Windows SDK rather than hard coding to 10.0.19613.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ between these "modes" does come at a runtime cost.
 ### Building
 
 In order to build the solution, please make sure you have the [Windows Insider Preview SDK](https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewSDK)
-installed. The current target is the SDK version: `10.0.19613.0`.
-
-Older Insider Preview SDKs can be found [here](https://docs.microsoft.com/en-us/windows-insider/flight-hub/).
+installed. 
 
 The solution can then be built either from Visual Studio or simply from the Visual Studio Developer
 Console using `msbuild`. For instance:
@@ -67,14 +65,9 @@ Console using `msbuild`. For instance:
 msbuild UIAutomation.sln /p:Configuration=Release,Platform=x64
 ```
 
-Should you install a newer SDK, you will need to re-target the projects to that version. (The simplest way
-is to search for `19613` in all `.vcxproj` files and update them to the new version.) Note, however,
-that there are no guarantees that the platform API will be unchanged and as such the project might not
-build or it could work differently at runtime.
-
-In the future, once the platform API has stabilized into an official SDK release, this project will
-target the stable version.
-
+As  these projects have been written against an older preview sdk (10.0.19613.0), there are no guarantees that the platform API will be unchanged and as such the project might not
+build or it could work differently at runtime on newer versions.
+ 
 # Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ Console using `msbuild`. For instance:
 msbuild UIAutomation.sln /p:Configuration=Release,Platform=x64
 ```
 
-As  these projects have been written against an older preview sdk (10.0.19613.0), there are no guarantees that the platform API will be unchanged and as such the project might not
-build or it could work differently at runtime on newer versions.
+These projects target SDK version 10.0. Note that breaking changes can occur in preview SDKs, so if you install a new preview SDK there are no guarantees that the platform API will be unchanged and as such the projects might not build or they could work differently at runtime.
  
 # Contributing
 

--- a/src/UIAutomation/FunctionalTests/FunctionalTests.vcxproj
+++ b/src/UIAutomation/FunctionalTests/FunctionalTests.vcxproj
@@ -24,7 +24,7 @@
     <ProjectGuid>{ADC03671-2DB4-4130-BC73-B78314046BFB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>FunctionalTests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19613.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -193,7 +193,7 @@
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Windows">
-      <HintPath>$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd</HintPath>
+      <HintPath>$(FrameworkSdkDir)UnionMetadata\$(TargetPlatformVersion)\Windows.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
   </ItemGroup>

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.vcxproj
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{7D645239-F96E-4FBE-BAA4-B92838B9D361}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>MicrosoftUIUIAutomation</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19613.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -105,7 +105,7 @@
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
     </Link>
     <Midl>
-      <AdditionalMetadataDirectories>$(FrameworkSdkDir)References\10.0.19613.0\Windows.Foundation.FoundationContract\4.0.0.0</AdditionalMetadataDirectories>
+      <AdditionalMetadataDirectories>$(FrameworkSdkDir)References\$(TargetPlatformVersion)\Windows.Foundation.FoundationContract\4.0.0.0</AdditionalMetadataDirectories>
     </Midl>
     <Midl>
       <EnableWindowsRuntime>true</EnableWindowsRuntime>
@@ -113,7 +113,7 @@
       <AdditionalOptions>/nomidl /struct_by_ref %(AdditionalOptions)</AdditionalOptions>
     </Midl>
     <CustomBuildStep>
-      <Command>cppwinrt.exe -in $(IntDir)$(ProjectName).winmd -comp "$(ProjectDir)Generated Files\Sources" -out "$(ProjectDir)Generated Files" -ref 10.0.19613.0 -prefix -name $(ProjectName) -optimize</Command>
+      <Command>cppwinrt.exe -in $(IntDir)$(ProjectName).winmd -comp "$(ProjectDir)Generated Files\Sources" -out "$(ProjectDir)Generated Files" -ref $(TargetPlatformVersion) -prefix -name $(ProjectName) -optimize</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Invoking cppwinrt.exe</Message>
@@ -123,7 +123,7 @@
       <Inputs>$(IntDir)$(ProjectName).winmd</Inputs>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
+      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\$(TargetPlatformVersion)\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy winmd to output directory</Message>
@@ -148,7 +148,7 @@
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
     </Link>
     <Midl>
-      <AdditionalMetadataDirectories>$(FrameworkSdkDir)References\10.0.19613.0\Windows.Foundation.FoundationContract\4.0.0.0</AdditionalMetadataDirectories>
+      <AdditionalMetadataDirectories>$(FrameworkSdkDir)References\$(TargetPlatformVersion)\Windows.Foundation.FoundationContract\4.0.0.0</AdditionalMetadataDirectories>
     </Midl>
     <Midl>
       <EnableWindowsRuntime>true</EnableWindowsRuntime>
@@ -156,7 +156,7 @@
       <AdditionalOptions>/nomidl /struct_by_ref %(AdditionalOptions)</AdditionalOptions>
     </Midl>
     <CustomBuildStep>
-      <Command>cppwinrt.exe -in $(IntDir)$(ProjectName).winmd -comp "$(ProjectDir)Generated Files\Sources" -out "$(ProjectDir)Generated Files" -ref 10.0.19613.0 -prefix -name $(ProjectName) -optimize</Command>
+      <Command>cppwinrt.exe -in $(IntDir)$(ProjectName).winmd -comp "$(ProjectDir)Generated Files\Sources" -out "$(ProjectDir)Generated Files" -ref $(TargetPlatformVersion) -prefix -name $(ProjectName) -optimize</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Invoking cppwinrt.exe</Message>
@@ -166,7 +166,7 @@
       <Inputs>$(IntDir)$(ProjectName).winmd</Inputs>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
+      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\$(TargetPlatformVersion)\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy winmd to output directory</Message>
@@ -195,7 +195,7 @@
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
     </Link>
     <Midl>
-      <AdditionalMetadataDirectories>$(FrameworkSdkDir)References\10.0.19613.0\Windows.Foundation.FoundationContract\4.0.0.0</AdditionalMetadataDirectories>
+      <AdditionalMetadataDirectories>$(FrameworkSdkDir)References\$(TargetPlatformVersion)\Windows.Foundation.FoundationContract\4.0.0.0</AdditionalMetadataDirectories>
     </Midl>
     <Midl>
       <EnableWindowsRuntime>true</EnableWindowsRuntime>
@@ -203,7 +203,7 @@
       <AdditionalOptions>/nomidl /struct_by_ref %(AdditionalOptions)</AdditionalOptions>
     </Midl>
     <CustomBuildStep>
-      <Command>cppwinrt.exe -in $(IntDir)$(ProjectName).winmd -comp "$(ProjectDir)Generated Files\Sources" -out "$(ProjectDir)Generated Files" -ref 10.0.19613.0 -prefix -name $(ProjectName) -optimize</Command>
+      <Command>cppwinrt.exe -in $(IntDir)$(ProjectName).winmd -comp "$(ProjectDir)Generated Files\Sources" -out "$(ProjectDir)Generated Files" -ref $(TargetPlatformVersion) -prefix -name $(ProjectName) -optimize</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Invoking cppwinrt.exe</Message>
@@ -213,7 +213,7 @@
       <Inputs>$(IntDir)$(ProjectName).winmd</Inputs>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
+      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\$(TargetPlatformVersion)\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy winmd to output directory</Message>
@@ -242,7 +242,7 @@
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
     </Link>
     <Midl>
-      <AdditionalMetadataDirectories>$(FrameworkSdkDir)References\10.0.19613.0\Windows.Foundation.FoundationContract\4.0.0.0</AdditionalMetadataDirectories>
+      <AdditionalMetadataDirectories>$(FrameworkSdkDir)References\$(TargetPlatformVersion)\Windows.Foundation.FoundationContract\4.0.0.0</AdditionalMetadataDirectories>
     </Midl>
     <Midl>
       <EnableWindowsRuntime>true</EnableWindowsRuntime>
@@ -250,7 +250,7 @@
       <AdditionalOptions>/nomidl /struct_by_ref %(AdditionalOptions)</AdditionalOptions>
     </Midl>
     <CustomBuildStep>
-      <Command>cppwinrt.exe -in $(IntDir)$(ProjectName).winmd -comp "$(ProjectDir)Generated Files\Sources" -out "$(ProjectDir)Generated Files" -ref 10.0.19613.0 -prefix -name $(ProjectName) -optimize</Command>
+      <Command>cppwinrt.exe -in $(IntDir)$(ProjectName).winmd -comp "$(ProjectDir)Generated Files\Sources" -out "$(ProjectDir)Generated Files" -ref $(TargetPlatformVersion) -prefix -name $(ProjectName) -optimize</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Invoking cppwinrt.exe</Message>
@@ -260,7 +260,7 @@
       <Inputs>$(IntDir)$(ProjectName).winmd</Inputs>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
+      <Command>(if not exist "$(OutDir)winmd" mkdir "$(OutDir)winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(OutDir)winmd\$(ProjectName).winmd" &amp;&amp; (if not exist "$(ProjectDir)Generated Files\winmd" mkdir "$(ProjectDir)Generated Files\winmd") &amp;&amp; copy "$(IntDir)$(ProjectName).winmd" "$(ProjectDir)Generated Files\winmd\$(ProjectName).winmd" &amp;&amp; copy "$(FrameworkSdkDir)UnionMetadata\$(TargetPlatformVersion)\Windows.winmd" "$(ProjectDir)Generated Files\winmd\Windows.winmd"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy winmd to output directory</Message>

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.vcxproj
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{7D645239-F96E-4FBE-BAA4-B92838B9D361}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -565,8 +565,8 @@ namespace UiaOperationAbstraction
 
     void UiaChar::FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result)
     {
-        static_assert(sizeof(uint16_t) == sizeof(wchar_t), "uint16_t needs to be the same as wchar_t");
-        m_member = static_cast<wchar_t>(winrt::unbox_value<uint16_t>(result));
+        static_assert(sizeof(char16_t) == sizeof(wchar_t), "char16_t needs to be the same as wchar_t");
+        m_member = static_cast<wchar_t>(winrt::unbox_value<char16_t>(result));
     }
 
     UiaString UiaString::Stringify()

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.vcxproj
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.vcxproj
@@ -24,7 +24,7 @@
     <ProjectGuid>{A5682ADB-8C0C-4CFD-AED9-2E979751FDCC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>UiaOperationAbstraction</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19613.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -177,7 +177,7 @@
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
     <Reference Include="Windows">
-      <HintPath>$(FrameworkSdkDir)UnionMetadata\10.0.19613.0\Windows.winmd</HintPath>
+      <HintPath>$(FrameworkSdkDir)UnionMetadata\$(TargetPlatformVersion)\Windows.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
## The issue
Currently this project targets the specific Windows SDK preview 10.0.19613.0.
 Not only is this sdk now very old, it is quite a headache for 3rd party projects to integrate this project, being forced to use that specific sdk.

## The solution
The vc++ projects (functional tests, Microsoft.UI.UIAutomation library, and abstraction API) all now target the latest Windows 10 SDK, rather than being hard coded to 10.0.19613.0.
    For each of the vcxxproj files, this involved:
    * changing WindowsTargetPlatFormVersion from 10.0.19613.0 to 10.0. VS 2019 supports this value as meaning the latest Windows 10 sdk version.
    * Find all references to 10.0.19613.0 (there were many hard-coded paths containing this) and replace them with $(TargetPlatformVersion), which expands to the actual latest Windows 10 sdk full version number.

## Testing
I was able to successfully build a release x86 version of the 3 vc++ projects with no build errors.
I am using Preview sdk 10.0.20295.0.

I ran the functional tests on Windows build Version Dev (OS Build 21327.1010).
All functional tests passed except for 1:
```
 StringIndexingRemote
   Source: UiaOperationAbstractionTests.cpp line 488
   Duration: 3.4 sec

  Message: 
    Unhandled C++ Exception
  Stack Trace: 
    winrt::throw_hresult() line 4777
    UiaChar::FromRemoteResult() line 569
    AutomationRemoteOperationResultSet &>::_Do_call() line 938
    UiaOperationScope::ResolveHrInternal() line 2209
    UiaOperationScope::Resolve() line 2177
    UiaOperationAbstractionTests::StringIndexing() line 466
```
 I have no idea if this is an issue stemming from the sdk, or my particular Windows insider build, or prhaps this test was already failing.
