### PR TITLE
Add explicit move assignment operator for UiaTuple

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -1327,8 +1327,12 @@ namespace UiaOperationAbstractionTests
                     UiaString{ L"WrapperConstructed" } /* stringValue */
                 };
 
+                UiaTuple<UiaElement, UiaInt, UiaBool, UiaString> moveAssignmentTuple{};
+                UiaTuple<UiaElement, UiaInt, UiaBool, UiaString> tempTuple{ focusedElement /* elementValue */, 3 /* intValue */, true /* booleanValue */, L"MoveAssignment" /* stringValue */ };
+                moveAssignmentTuple = std::move(tempTuple);
+
                 // Return the results of the comparisons.
-                operationScope.BindResult(defaultConstructedTuple, localConstructedTuple, wrapperConstructedTuple);
+                operationScope.BindResult(defaultConstructedTuple, localConstructedTuple, wrapperConstructedTuple, moveAssignmentTuple);
                 operationScope.Resolve();
 
                 // Represents a local result of `UiaTuple<UiaElement, UiaInt, UiaBool, UiaString>`
@@ -1380,6 +1384,13 @@ namespace UiaOperationAbstractionTests
                 {
                     const LocalTupleResult expectedResult{ L"Display is 0" /* name */, 2 /* numericValue */, true /* booleanValue */, L"WrapperConstructed" /* stringValue */ };
                     const auto actualResult = LocalTupleResult::FromResult(wrapperConstructedTuple);
+                    LocalTupleResult::TestEqual(expectedResult, actualResult);
+                }
+
+                // -> `UiaTuple` using move assignment.
+                {
+                    const LocalTupleResult expectedResult{ L"Display is 0" /* name */, 3 /* numericValue */, true /* booleanValue */, L"MoveAssignment" /* stringValue */ };
+                    const auto actualResult = LocalTupleResult::FromResult(moveAssignmentTuple);
                     LocalTupleResult::TestEqual(expectedResult, actualResult);
                 }
             }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -581,6 +581,8 @@ namespace UiaOperationAbstraction
         UiaTypeBase(UiaTypeBase&&) = default;
         UiaTypeBase& operator=(UiaTypeBase&&) = default;
 
+        ~UiaTypeBase() = default;
+
         constexpr bool IsRemoteType() const
         {
             return std::holds_alternative<RemoteType>(m_member);

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1891,6 +1891,12 @@ namespace UiaOperationAbstraction
         }
 
         UiaTuple(const UiaTuple&) = default;
+        UiaTuple& operator=(const UiaTuple&) = delete;
+
+        UiaTuple(UiaTuple&&) = default;
+        UiaTuple& operator=(UiaTuple&&) = default;
+
+        ~UiaTuple() = default;
 
         UiaBool IsNull() const
         {
@@ -1906,9 +1912,6 @@ namespace UiaOperationAbstraction
             // The local version of a UiaTuple can never be null.
             return false;
         }
-
-        UiaTuple(UiaTuple&&) = default;
-        UiaTuple& operator=(UiaTuple&&) = default;
 
         UiaBool operator!() const { return IsNull(); }
         operator UiaBool() const { return !IsNull(); }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1907,6 +1907,9 @@ namespace UiaOperationAbstraction
             return false;
         }
 
+        UiaTuple(UiaTuple&&) = default;
+        UiaTuple& operator=(UiaTuple&&) = default;
+
         UiaBool operator!() const { return IsNull(); }
         operator UiaBool() const { return !IsNull(); }
 


### PR DESCRIPTION
There is no explicit reason to avoid UiaTuple make move assignments.
But UiaTuple cannot just get the inherent function from UiaTypeBase.
This PR defines the move assignment operator and move constructor for UiaTuple explicitly.

Closes #66 