### PR TITLE
UiaOperationAbstraction: expose GetPropertyValue as a method on UiaElement

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -205,10 +205,10 @@ namespace UiaOperationAbstractionTests
             GetPropertyValueFetchNameTest(true);
         }
 
-            // Tests that GetPropertyValue with ignoreDefault true raises an exception on an unimplemented property ID
+        // Tests that GetPropertyValue with ignoreDefault true raises an exception on an unimplemented property ID
         // and that ignoreDefault false correctly returns a default value.
         void GetPropertyValueIgnoreDefaultTest(const bool useRemoteOperations)
-                {
+        {
             ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
             app.Activate();
             auto calc = WaitForElementFocus(L"Display is 0");
@@ -235,7 +235,7 @@ namespace UiaOperationAbstractionTests
         }
 
         TEST_METHOD(GetPropertyValueIgnoreDefaultLocalTest)
-                {
+        {
             GetPropertyValueIgnoreDefaultTest(false);
         }
 
@@ -247,7 +247,7 @@ namespace UiaOperationAbstractionTests
         // Tests GetPropertyValue with useCachedAPI set to true and false
         // Ensuring that an exception is raised if trying to fetch a cached value that is not cached. 
         void GetPropertyValueUseCachedAPITest(const bool useRemoteOperations)
-                {
+        {
             ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
             app.Activate();
             auto calc = WaitForElementFocus(L"Display is 0");
@@ -263,7 +263,7 @@ namespace UiaOperationAbstractionTests
             cacheRequest.AddProperty(UIA_NamePropertyId);
 
             auto elementWithCache = elementWithoutCache.GetUpdatedCacheElement(cacheRequest);
-scope.BindResult(elementWithCache);
+            scope.BindResult(elementWithCache);
 
             scope.Resolve();
 
@@ -271,7 +271,7 @@ scope.BindResult(elementWithCache);
             Assert::AreEqual(std::wstring(static_cast<wil::shared_bstr>(cachedName).get()), std::wstring(L"Display is 0"));
 
             Assert::ExpectException<winrt::hresult_error>([&]()
-                {
+            {
                 elementWithoutCache.GetPropertyValue(UiaPropertyId(UIA_NamePropertyId), /*ignoreDefault=*/ false, /*useCachedApi=*/ true);
             });
 
@@ -280,7 +280,7 @@ scope.BindResult(elementWithCache);
         }
 
         TEST_METHOD(GetPropertyValueUseCachedAPILocalTest)
-                {
+        {
             GetPropertyValueUseCachedAPITest(false);
         }
 

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -219,12 +219,12 @@ namespace UiaOperationAbstractionTests
 
             UiaElement element = calc;
 
-            auto defaultVal = element.GetPropertyValue(UiaPropertyId(UIA_AriaPropertiesPropertyId), false);
+            auto defaultVal = element.GetPropertyValue(UiaPropertyId(UIA_AriaPropertiesPropertyId), false /*ignoreDefault*/);
             scope.BindResult(defaultVal);
             auto ariaProperties = defaultVal.AsString();
             scope.BindResult(ariaProperties);
 
-            auto notSupportedVal = element.GetPropertyValue(UiaPropertyId(UIA_AriaPropertiesPropertyId), true);
+            auto notSupportedVal = element.GetPropertyValue(UiaPropertyId(UIA_AriaPropertiesPropertyId), true /*ignoreDefault*/);
             scope.BindResult(notSupportedVal);
 
             scope.Resolve();

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -267,16 +267,19 @@ namespace UiaOperationAbstractionTests
 
             scope.Resolve();
 
-            UiaString cachedName = elementWithCache.GetPropertyValue(UiaPropertyId(UIA_NamePropertyId), /*ignoreDefault=*/ false, /*useCachedApi=*/ true).AsString();
-            Assert::AreEqual(std::wstring(static_cast<wil::shared_bstr>(cachedName).get()), std::wstring(L"Display is 0"));
+            UiaString cachedNameFromElementWithCache = elementWithCache.GetPropertyValue(UiaPropertyId(UIA_NamePropertyId), /*ignoreDefault=*/ false, /*useCachedApi=*/ true).AsString();
+            Assert::AreEqual(std::wstring(static_cast<wil::shared_bstr>(cachedNameFromElementWithCache).get()), std::wstring(L"Display is 0"));
+
+            UiaString uncachedNameFromElementWithCache = elementWithCache.GetPropertyValue(UiaPropertyId(UIA_NamePropertyId), /*ignoreDefault=*/ false, /*useCachedApi=*/ false).AsString();
+            Assert::AreEqual(std::wstring(static_cast<wil::shared_bstr>(uncachedNameFromElementWithCache).get()), std::wstring(L"Display is 0"));
 
             Assert::ExpectException<winrt::hresult_error>([&]()
             {
                 elementWithoutCache.GetPropertyValue(UiaPropertyId(UIA_NamePropertyId), /*ignoreDefault=*/ false, /*useCachedApi=*/ true);
             });
 
-            UiaString uncachedName = elementWithoutCache.GetPropertyValue(UiaPropertyId(UIA_NamePropertyId), /*ignoreDefault=*/ false, /*useCachedApi=*/ false).AsString();
-            Assert::AreEqual(std::wstring(static_cast<wil::shared_bstr>(uncachedName).get()), std::wstring(L"Display is 0"));
+            UiaString uncachedNameFromElementWithoutCache = elementWithoutCache.GetPropertyValue(UiaPropertyId(UIA_NamePropertyId), /*ignoreDefault=*/ false, /*useCachedApi=*/ false).AsString();
+            Assert::AreEqual(std::wstring(static_cast<wil::shared_bstr>(uncachedNameFromElementWithoutCache).get()), std::wstring(L"Display is 0"));
         }
 
         TEST_METHOD(GetPropertyValueUseCachedAPILocalTest)

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -174,6 +174,37 @@ namespace UiaOperationAbstractionTests
             ElementGetNameTest(true);
         }
 
+        // Asserts that you can get the name of a UiaElement via a property ID.
+        void ElementGetNameViaGetPropertyValueTest(const bool useRemoteOperations)
+        {
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+            auto calc = WaitForElementFocus(L"Display is 0");
+
+            auto guard = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            auto scope = UiaOperationScope::StartNew();
+
+            UiaElement element = calc;
+            auto val = element.GetPropertyValue(UiaPropertyId(UIA_NamePropertyId));
+            auto name = val.AsString();
+            scope.BindResult(name);
+
+            scope.Resolve();
+
+            Assert::AreEqual(std::wstring(static_cast<wil::shared_bstr>(name).get()), std::wstring(L"Display is 0"));
+        }
+
+        TEST_METHOD(ElementGetNameViaGetPropertyValueLocalTest)
+        {
+            ElementGetNameViaGetPropertyValueTest(false);
+        }
+
+        TEST_METHOD(ElementGetNameViaGetPropertyValueRemoteTest)
+        {
+            ElementGetNameViaGetPropertyValueTest(true);
+        }
+
         // Asserts that you can get the runtime id of a UiaElement.
         void ElementGetRuntimeIdTest(const bool useRemoteOperations)
         {

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -2029,7 +2029,7 @@ namespace UiaOperationAbstraction
         return !(*this == rhs);
     }
 
-    UiaBool UiaVariant::IsNotSupported(_In_ const IUnknown* unsupportedAttributeValue) const
+    UiaBool UiaVariant::IsNotSupported() const
     {
         if (ShouldUseRemoteApi())
         {
@@ -2045,10 +2045,15 @@ namespace UiaOperationAbstraction
             }
         }
         const auto localValue = std::get<std::shared_ptr<wil::unique_variant>>(m_member);
-        return (localValue->vt == VT_UNKNOWN) && (localValue->punkVal == unsupportedAttributeValue);
+        if(localValue->vt == VT_UNKNOWN) {
+            wil::com_ptr<IUnknown> notSupportedVal;
+            g_automation.get()->get_ReservedNotSupportedValue(&notSupportedVal);
+            return localValue->punkVal == notSupportedVal.get();
+        }
+        return false;
     }
 
-    UiaBool UiaVariant::IsMixedAttribute(_In_ const IUnknown* mixedAttributeValue) const
+    UiaBool UiaVariant::IsMixedAttribute() const
     {
         if (ShouldUseRemoteApi())
         {
@@ -2064,7 +2069,12 @@ namespace UiaOperationAbstraction
             }
         }
         const auto localValue = std::get<std::shared_ptr<wil::unique_variant>>(m_member);
-        return (localValue->vt == VT_UNKNOWN) && (localValue->punkVal == mixedAttributeValue);
+        if(localValue->vt == VT_UNKNOWN) {
+            wil::com_ptr<IUnknown> mixedAttributeVal;
+            g_automation.get()->get_ReservedMixedAttributeValue(&mixedAttributeVal);
+            return localValue->punkVal == mixedAttributeVal.get();
+        }
+        return false;
     }
 
     UiaBool UiaVariant::IsBool() const

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1743,12 +1743,9 @@ namespace UiaOperationAbstraction
 
         VARIANT get() const;
 
-        // It would be nice if this didn't have to be told what the unsupported attribute value is,
-        // but we don't have an IUIAutomation object handy in this library so it does.
-        UiaBool IsNotSupported(_In_ const IUnknown* unsupportedAttributeValue) const;
+        UiaBool IsNotSupported() const;
 
-        // Same for the mixed attribute value.
-        UiaBool IsMixedAttribute(_In_ const IUnknown* mixedAttributeValue) const;
+        UiaBool IsMixedAttribute() const;
 
         template<typename WrapperType>
         UiaBool IsType() const

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
@@ -2057,6 +2057,7 @@
 
         UiaBool IsNull() const;
 
+        UiaVariant GetPropertyValue(UiaPropertyId propId, UiaBool ignoreDefault = false, bool useCachedApi = false);
         UiaArray<UiaInt> GetRuntimeId();
         UiaInt GetProcessId(bool useCachedApi = false);
         UiaControlType GetControlType(bool useCachedApi = false);

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
@@ -5114,7 +5114,7 @@
         return localPropertyValue;
     }
 
-    UiaVariant UiaElement::GetPropertyValue(UiaPropertyId propId, UiaBool ignoreDefault, bool useCachedApi)
+    UiaVariant UiaElement::GetPropertyValue(UiaPropertyId propId, UiaBool ignoreDefault /* = false */, bool useCachedApi /* = false */)
     {
         auto delegator = UiaOperationScope::GetCurrentDelegator();
         if (delegator && delegator->GetUseRemoteApi())

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
@@ -5114,6 +5114,31 @@
         return localPropertyValue;
     }
 
+    UiaVariant UiaElement::GetPropertyValue(UiaPropertyId propId, UiaBool ignoreDefault, bool useCachedApi)
+    {
+        auto delegator = UiaOperationScope::GetCurrentDelegator();
+        if (delegator && delegator->GetUseRemoteApi())
+        {
+            this->ToRemote();
+            propId.ToRemote();
+            ignoreDefault.ToRemote();
+            return std::get<AutomationRemoteElement>(m_member).GetPropertyValue(propId, ignoreDefault);
+        }
+
+        auto localObject = std::get<winrt::com_ptr<IUIAutomationElement>>(m_member);
+        wil::unique_variant localPropertyValue;
+        if (useCachedApi)
+        {
+            winrt::check_hresult(localObject->GetCachedPropertyValueEx(propId, ignoreDefault, &localPropertyValue));
+        }
+        else
+        {
+            winrt::check_hresult(localObject->GetCurrentPropertyValueEx(propId, ignoreDefault, &localPropertyValue));
+        }
+
+        return localPropertyValue;
+    }
+
     UiaInt UiaElement::GetProcessId(bool useCachedApi /* = false */)
     {
         auto delegator = UiaOperationScope::GetCurrentDelegator();


### PR DESCRIPTION
UiaOperationAbstraction's UiaElement class currently has getter methods for most if not all standard UIA properties (E.g. GetName, GetControlType etc). However, there is no way to cleanly fetch a property value by a given property ID. Exposing GetPropertyValue would be useful for the following reasons:
* Calling logic may want to fetch a long list of properties. Rather than having to hard-code calls to the individual getter methods, it would be much easier to just walk through a for loop of property IDs, calling GetPropertyValue generically with each property ID.
* UI Automation has the concept of custom properties, and Microsoft products seem to be moving towards using these more heavily these days. Assuming that Microsoft.UI.UIAutomation.AutomationRemoteElement.GetPropertyValue and its underlying machinary do already correctly marshal custom property IDs, then exposing GetProprtyValue on UiaElement would allow for fetching these.

This PR exposes GetPropertyValue on UiaElement. Remotely it uses AutomationRemoteElement.GetPropertyValue, and locally it uses IUIAutomationElement.GetCurrentPropertyValue or IUIAutomationElement.GetCachedPropertyValue (depending on whether caching is requested). It also takes a 'ignoreDefault' boolean argument, and its return type is a UiaVariant.
I have also added a basic functional test which fetches name via GetPropertyValue and asserts the string returned is correct.