### PR TITLE
UiaOperationAbstraction:  allow converting a UiaElement to a UiaVariant and back again 

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -1934,5 +1934,42 @@ namespace UiaOperationAbstractionTests
         {
             UiaVariantCastUiaEnumTest(true /* useRemoteOperations */);
         }
+
+        // Asserts that you can convert a UiaElement to / from a UiaVariant 
+        void ElementAsVariantTest(const bool useRemoteOperations)
+        {
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+            auto calc = WaitForElementFocus(L"Display is 0");
+
+            auto guard = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            auto scope = UiaOperationScope::StartNew();
+
+            UiaElement element = calc;
+            auto ev = UiaVariant(element);
+            auto ev_IsElement = ev.IsElement();
+            scope.BindResult(ev_IsElement);
+            
+            auto ev_AsElement = ev.AsElement();
+
+            auto name = ev_AsElement.GetName(false /*useCachedApi*/);
+            scope.BindResult(name);
+
+            scope.Resolve();
+
+            Assert::IsTrue(static_cast<bool>(ev_IsElement));
+            Assert::AreEqual(std::wstring(static_cast<wil::shared_bstr>(name).get()), std::wstring(L"Display is 0"));
+        }
+
+        TEST_METHOD(ElementAsVariantLocalTest)
+        {
+            ElementAsVariantTest(false);
+        }
+
+        TEST_METHOD(ElementAsVariantRemoteTest)
+        {
+            ElementAsVariantTest(true);
+        }
     };
 }

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -1947,18 +1947,18 @@ namespace UiaOperationAbstractionTests
             auto scope = UiaOperationScope::StartNew();
 
             UiaElement element = calc;
-            auto ev = UiaVariant(element);
-            auto ev_IsElement = ev.IsElement();
-            scope.BindResult(ev_IsElement);
+            auto variantFromElement = UiaVariant(element);
+            auto variantIsElement = variantFromElement.IsElement();
+            scope.BindResult(variantIsElement);
             
-            auto ev_AsElement = ev.AsElement();
+            auto elementFromVariant = variantFromElement.AsElement();
 
-            auto name = ev_AsElement.GetName(false /*useCachedApi*/);
+            auto name = elementFromVariant.GetName(false /*useCachedApi*/);
             scope.BindResult(name);
 
             scope.Resolve();
 
-            Assert::IsTrue(static_cast<bool>(ev_IsElement));
+            Assert::IsTrue(static_cast<bool>(variantIsElement));
             Assert::AreEqual(std::wstring(static_cast<wil::shared_bstr>(name).get()), std::wstring(L"Display is 0"));
         }
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -2128,55 +2128,12 @@ namespace UiaOperationAbstraction
 
     UiaBool UiaVariant::IsElement() const
     {
-        if (ShouldUseRemoteApi())
-        {
-            auto remoteObject = std::get<RemoteType>(m_member);
-            auto remoteAny = remoteObject.try_as<AutomationRemoteAnyObject>();
-            if (remoteAny)
-            {
-                return remoteAny.IsElement();
-            }
-            auto remoteDerived = remoteObject.try_as<typename UiaElement::RemoteType>();
-                    if (remoteDerived)
-                    {
-                        return true;
-                    }
-            return false;
-        }
-        auto localValue = std::get<typename LocalType>(m_member);
-        if(V_VT(localValue) != UiaElement::c_comVariantType) {
-            return false;
-        }
-        winrt::com_ptr<IUnknown> punk;
-        punk.copy_from(localValue->punkVal);
-        if(punk.try_as<UiaElement::LocalType::type>()) {
-            return true;
-        }
-        return false;
+        return IsType<UiaElement>();
     }
 
     UiaElement UiaVariant::AsElement() const
     {
-        if (ShouldUseRemoteApi())
-        {
-            auto remoteObject = std::get<RemoteType>(m_member);
-            auto remoteAny = remoteObject.try_as<AutomationRemoteAnyObject>();
-            if (remoteAny)
-            {
-                return remoteAny.AsElement();
-            }
-            auto remoteDerived = remoteObject.try_as<typename UiaElement::RemoteType>();
-                    if (remoteDerived)
-                    {
-                        return remoteDerived;
-                    }
-            THROW_HR(E_UNEXPECTED);
-        }
-        auto localValue = std::get<typename LocalType>(m_member);
-        THROW_HR_IF(E_INVALIDARG, V_VT(localValue) != UiaElement::c_comVariantType);
-        winrt::com_ptr<IUnknown> punk;
-        punk.copy_from(localValue->punkVal);
-        return punk.as<UiaElement::LocalType::type>();
+        return AsType<UiaElement>();
     }
 
         UiaVariant::operator std::shared_ptr<wil::unique_variant>() const

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -1946,6 +1946,15 @@ namespace UiaOperationAbstraction
         ToRemote();
     }
 
+    UiaVariant::UiaVariant(UiaElement value) :
+        UiaTypeBase(
+            value.IsRemoteType() ?
+            UiaVariant(static_cast<AutomationRemoteObject>(static_cast<UiaElement::RemoteType>(value))) :
+            UiaVariant(details::MakeVariantFrom<UiaElement>(wil::com_ptr<IUIAutomationElement>(value.get()).detach())))
+    {
+        ToRemote();
+    }
+
     UiaBool UiaVariant::IsNull() const
     {
         if (ShouldUseRemoteApi())
@@ -2117,7 +2126,60 @@ namespace UiaOperationAbstraction
         return AsType<UiaString>();
     }
 
-    UiaVariant::operator std::shared_ptr<wil::unique_variant>() const
+    UiaBool UiaVariant::IsElement() const
+    {
+        if (ShouldUseRemoteApi())
+        {
+            auto remoteObject = std::get<RemoteType>(m_member);
+            auto remoteAny = remoteObject.try_as<AutomationRemoteAnyObject>();
+            if (remoteAny)
+            {
+                return remoteAny.IsElement();
+            }
+            auto remoteDerived = remoteObject.try_as<typename UiaElement::RemoteType>();
+                    if (remoteDerived)
+                    {
+                        return true;
+                    }
+            return false;
+        }
+        auto localValue = std::get<typename LocalType>(m_member);
+        if(V_VT(localValue) != UiaElement::c_comVariantType) {
+            return false;
+        }
+        winrt::com_ptr<IUnknown> punk;
+        punk.copy_from(localValue->punkVal);
+        if(punk.try_as<UiaElement::LocalType::type>()) {
+            return true;
+        }
+        return false;
+    }
+
+    UiaElement UiaVariant::AsElement() const
+    {
+        if (ShouldUseRemoteApi())
+        {
+            auto remoteObject = std::get<RemoteType>(m_member);
+            auto remoteAny = remoteObject.try_as<AutomationRemoteAnyObject>();
+            if (remoteAny)
+            {
+                return remoteAny.AsElement();
+            }
+            auto remoteDerived = remoteObject.try_as<typename UiaElement::RemoteType>();
+                    if (remoteDerived)
+                    {
+                        return remoteDerived;
+                    }
+            THROW_HR(E_UNEXPECTED);
+        }
+        auto localValue = std::get<typename LocalType>(m_member);
+        THROW_HR_IF(E_INVALIDARG, V_VT(localValue) != UiaElement::c_comVariantType);
+        winrt::com_ptr<IUnknown> punk;
+        punk.copy_from(localValue->punkVal);
+        return punk.as<UiaElement::LocalType::type>();
+    }
+
+        UiaVariant::operator std::shared_ptr<wil::unique_variant>() const
     {
         return std::get<std::shared_ptr<wil::unique_variant>>(m_member);
     }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -2136,7 +2136,7 @@ namespace UiaOperationAbstraction
         return AsType<UiaElement>();
     }
 
-        UiaVariant::operator std::shared_ptr<wil::unique_variant>() const
+    UiaVariant::operator std::shared_ptr<wil::unique_variant>() const
     {
         return std::get<std::shared_ptr<wil::unique_variant>>(m_member);
     }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1773,7 +1773,8 @@ namespace UiaOperationAbstraction
             auto localValue = std::get<typename LocalType>(m_member);
             bool isType = V_VT(localValue) == WrapperType::c_comVariantType;
             if(!isType) return false;
-            if constexpr(WrapperType::c_comVariantType == VT_UNKNOWN) {
+            if constexpr(WrapperType::c_comVariantType == VT_UNKNOWN)
+            {
                 // wrapper types representing COM objects such as UiaElement are stored as an IUnknown in variants.
                 // Therefore they require an extra QI to their actual interface.
                 winrt::com_ptr<IUnknown> punk;
@@ -1806,13 +1807,16 @@ namespace UiaOperationAbstraction
             }
             auto localValue = std::get<typename LocalType>(m_member);
             THROW_HR_IF(E_INVALIDARG, V_VT(localValue) != ReturnType::c_comVariantType);
-            if constexpr(ReturnType::c_comVariantType == VT_UNKNOWN) {
+            if constexpr(ReturnType::c_comVariantType == VT_UNKNOWN)
+            {
                 // wrapper types representing COM objects such as UiaElement are stored as an IUnknown in variants.
                 // Therefore they require an extra QI to their actual interface.
                 winrt::com_ptr<IUnknown> punk;
                 punk.copy_from(localValue->punkVal);
                 return punk.as<ReturnType::LocalType::type>();
-            } else {
+            }
+            else
+            {
                 return static_cast<typename ReturnType::LocalType>((*localValue).*(ReturnType::c_variantMember));
             }
         }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -29,6 +29,9 @@ namespace UiaOperationAbstraction
 {
     using unique_safearray = wil::unique_any<SAFEARRAY*, decltype(&::SafeArrayDestroy), ::SafeArrayDestroy>;
 
+    // Forward declare UiaElement as it is used in a constructor for UiaVariant 
+    class UiaElement;
+
     // This type is representing a function type, where the return type is a template parameter, the function should be
     // a const member function of class `winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject`, the parameter
     // list is void.
@@ -1719,6 +1722,7 @@ namespace UiaOperationAbstraction
         explicit UiaVariant(UiaUint value);
         explicit UiaVariant(UiaDouble value);
         explicit UiaVariant(UiaString value);
+        explicit UiaVariant(UiaElement value);
 
         template <typename ComEnumT, typename WinRTEnumT, typename StandinT, CastFuncType<StandinT> CastFunc>
         explicit UiaVariant(UiaEnum<ComEnumT, WinRTEnumT, StandinT, CastFunc> value) :
@@ -1811,6 +1815,9 @@ namespace UiaOperationAbstraction
 
         UiaBool IsString() const;
         UiaString AsString() const;
+
+        UiaBool IsElement() const;
+        UiaElement AsElement() const;
 
         operator winrt::Microsoft::UI::UIAutomation::AutomationRemoteObject() const;
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -29,7 +29,6 @@ namespace UiaOperationAbstraction
 {
     using unique_safearray = wil::unique_any<SAFEARRAY*, decltype(&::SafeArrayDestroy), ::SafeArrayDestroy>;
 
-    // Forward declare UiaElement as it is used in a constructor for UiaVariant 
     class UiaElement;
 
     // This type is representing a function type, where the return type is a template parameter, the function should be

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -1774,6 +1774,8 @@ namespace UiaOperationAbstraction
             bool isType = V_VT(localValue) == WrapperType::c_comVariantType;
             if(!isType) return false;
             if constexpr(WrapperType::c_comVariantType == VT_UNKNOWN) {
+                // wrapper types representing COM objects such as UiaElement are stored as an IUnknown in variants.
+                // Therefore they require an extra QI to their actual interface.
                 winrt::com_ptr<IUnknown> punk;
                 punk.copy_from(localValue->punkVal);
                 isType = !!punk.try_as<typename WrapperType::LocalType::type>();
@@ -1805,6 +1807,8 @@ namespace UiaOperationAbstraction
             auto localValue = std::get<typename LocalType>(m_member);
             THROW_HR_IF(E_INVALIDARG, V_VT(localValue) != ReturnType::c_comVariantType);
             if constexpr(ReturnType::c_comVariantType == VT_UNKNOWN) {
+                // wrapper types representing COM objects such as UiaElement are stored as an IUnknown in variants.
+                // Therefore they require an extra QI to their actual interface.
                 winrt::com_ptr<IUnknown> punk;
                 punk.copy_from(localValue->punkVal);
                 return punk.as<ReturnType::LocalType::type>();

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
@@ -2015,6 +2015,9 @@
         winrt::Microsoft::UI::UIAutomation::AutomationRemoteElement>
     {
     public:
+        static constexpr VARTYPE c_comVariantType = VT_UNKNOWN;
+        static constexpr auto c_variantMember = &VARIANT::punkVal;
+        static constexpr auto c_anyTest = &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::IsElement;
         static constexpr auto c_anyCast = &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsElement;
 
         UiaElement(_In_ IUIAutomationElement* element);


### PR DESCRIPTION
UiaOperationAbstraction has a UiaVariant type for storing data of many types. This is very useful inconjunction with the UiaArray or UiaStringMap types, allowing for holding collections of data of varying types.
Although all the basic data types (UiaInt, UiaString, UiaBool etc) are supported by UiaVariant, UiaElement is not. Meaning that it is impossible to store a UiaElement in a UiaArray or UiaStringMap of variants.
 
this pr allows constructing a UiaVariant given a UiaElement as its constructor argument. UiaVariant also now exposes an IsElement method for checking if the variant is holding a UiaElement, and an AsElement method, which allows for fetching the UiaElement as a UiaElement.
 
This work involved:
* Adding the appropriate helper members to UiaElement for partispating in UiaVariant conversion such as: 
 * c_comVariantType, set to VT_UNKNOWN (IUnknown)
 * c_variantMember, pointing to VARIANT::punkVal
 * c_anyTest, pointing to AutomationRemoteAnyObject::IsElement
 * c_anyCast was already there.
* Adding an explicit constructor for UiaVariant which takes a UiaElement
* adding IsElement and HasElement methods to UiaVariant.

I have also added a function test that successfully tests constructing a UiaVariant from a UIAElement, varifying that IsElement is True, fetching the element with HasElement, and verifying it is a functioning and correct UiaElement by checking its name property.
 
In the process of writing this pr, I did need to forward declare UiaElement in UiaOperationAstraction.h, as the UiaElement name is required now by UiaVariant. I'm not sure if this is okay, or there is a cleaner way to do this?

Also I'd appreciate careful review of the UiaVariant constructor that takes a UiaElement, especially the bit handling construction of the local type:
```
UiaVariant(details::MakeVariantFrom<UiaElement>(wil::com_ptr<IUIAutomationElement>(value.get()).detach())))
```
The existing coding style here shoving everything into the member initializer makes for hard reading. 