### PR TITLE
Add support for TryBlock and CatchBlock in UiaOperationAbstraction wrapper

### DIFF
--- a/src/UIAutomation/FunctionalTests/pch.h
+++ b/src/UIAutomation/FunctionalTests/pch.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <variant>
 
+#include <wil/cppwinrt.h>
 #include <wil/resource.h>
 #include <wil/result.h>
 #include <wil/com.h>

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -760,6 +760,18 @@ namespace UiaOperationAbstraction
         g_automation.get().reset();
     }
 
+    // UiaFailure
+    UiaInt UiaFailure::GetCurrentFailureCode()
+    {
+        if (m_useRemoteApi && m_remoteOperation)
+        {
+            return m_remoteOperation.GetCurrentFailureCode();
+        }
+
+        return wil::ResultFromCaughtException();
+    }
+
+    // UiaOperationDelegator
     UiaOperationDelegator::UiaOperationDelegator() :
         UiaOperationDelegator(g_useRemoteOperations)
     {

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -763,11 +763,14 @@ namespace UiaOperationAbstraction
     // UiaFailure
     UiaInt UiaFailure::GetCurrentFailureCode()
     {
-        if (m_useRemoteApi && m_remoteOperation)
+        if (m_useRemoteApi)
         {
             return m_remoteOperation.GetCurrentFailureCode();
         }
 
+        // wil::ResultFromCaughtException needs to be used only inside the catch block.
+        // Usually it rethrows the error in the catch block and using it outside the catch
+        // block could crash the process.
         return wil::ResultFromCaughtException();
     }
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -74,13 +74,29 @@ namespace UiaOperationAbstraction
     class UiaFailure
     {
     public:
-        UiaFailure(const winrt::Microsoft::UI::UIAutomation::AutomationRemoteOperation remoteOperation, const bool useRemoteApi) :
-            m_remoteOperation(remoteOperation),
-            m_useRemoteApi(useRemoteApi) {}
+        // Make UiaOperationDelegator a friend class for UiaFailure and make the UiaFailure
+        // constructor private so that only UiaOperationDelegator can create instances for
+        // UiaFailure in try/catch. This is necessary as UiaFailure contains GetCurrentFailureCode() which
+        // returns the last failure code in both remote/local cases. The local case uses 
+        // wil::ResultFromCaughtException which should be invoked only inside catch block as it
+        // rethows the exception and when called outside the catch block can crash the application.
+        friend class UiaOperationDelegator;
+
+        // Delete copy/move constructors.
+        UiaFailure(const UiaFailure&) = delete;
+        UiaFailure& operator=(const UiaFailure&) = delete;
+
+        UiaFailure(UiaFailure&&) = delete;
+        UiaFailure& operator=(UiaFailure&&) = delete;
 
         UiaInt GetCurrentFailureCode();
 
     private:
+        // Private constructor used only by the TryCatch/Try of UiaOperationDelegator.
+        UiaFailure(const winrt::Microsoft::UI::UIAutomation::AutomationRemoteOperation remoteOperation, const bool useRemoteApi) :
+            m_remoteOperation(remoteOperation),
+            m_useRemoteApi(useRemoteApi) {}
+
         const bool m_useRemoteApi;
         const winrt::Microsoft::UI::UIAutomation::AutomationRemoteOperation m_remoteOperation;
     };

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -89,6 +89,8 @@ namespace UiaOperationAbstraction
         UiaFailure(UiaFailure&&) = delete;
         UiaFailure& operator=(UiaFailure&&) = delete;
 
+        ~UiaFailure() = default;
+
         UiaInt GetCurrentFailureCode();
 
     private:

--- a/src/UIAutomation/UiaOperationAbstraction/pch.h
+++ b/src/UIAutomation/UiaOperationAbstraction/pch.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <wil/cppwinrt.h>
 #include <unknwn.h>
 #include <Windows.h>
 #include <UIAutomation.h>


### PR DESCRIPTION
This PR add the Try/Catch helpers in UiaOperationAbstraction wrappers. It also add a helper for GetCurrentFailureCode.