### PR TITLE
UIA Operation Abstraction lib: implement support for CallExtension / IsExtensionSupported

### DIFF
--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -724,7 +724,7 @@ namespace UiaOperationAbstraction
 
     UiaPropertyId UiaGuid::LookupPropertyId()
     {
-    if (ShouldUseRemoteApi())
+        if (ShouldUseRemoteApi())
         {
             ToRemote();
             auto remoteValue = std::get_if<RemoteType>(&m_member);

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -738,6 +738,11 @@ namespace UiaOperationAbstraction
         return UiaLookupId(AutomationIdentifierType_Property, &localValue);
     }
 
+    UiaGuid::operator winrt::guid() const
+    {
+        return std::get<winrt::guid>(m_member);
+    }
+
     void UiaGuid::FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result)
     {
         m_member = winrt::unbox_value<GUID>(result);

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -674,6 +674,76 @@ namespace UiaOperationAbstraction
         }
     }
 
+    UiaGuid::UiaGuid(const winrt::guid& value):
+        UiaTypeBase(value)
+    {
+        ToRemote();
+    }
+
+    UiaGuid::UiaGuid(winrt::Microsoft::UI::UIAutomation::AutomationRemoteGuid remoteValue):
+        UiaTypeBase(remoteValue)
+    {
+    }
+
+    UiaGuid::UiaGuid(winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject remoteValue):
+        UiaTypeBase(remoteValue.AsGuid())
+    {
+    }
+
+    UiaGuid& UiaGuid::operator=(const UiaGuid& other)
+    {
+        AssignCopyTo<UiaGuid>(this->m_member, other.m_member);
+        return *this;
+    }
+
+    UiaBool UiaGuid::operator==(const UiaGuid& rhs) const
+    {
+        return BinaryOperator<UiaGuid, Equal>(this->m_member, rhs.m_member);
+    }
+
+    UiaBool UiaGuid::operator!=(const UiaGuid& rhs) const
+    {
+        return BinaryOperator<UiaGuid, NotEqual>(this->m_member, rhs.m_member);
+    }
+
+    UiaAnnotationType UiaGuid::LookupAnnotationType()
+    {
+        if (ShouldUseRemoteApi())
+        {
+            ToRemote();
+            auto remoteValue = std::get_if<RemoteType>(&m_member);
+            if (remoteValue)
+            {
+                return remoteValue->LookupAnnotationType();
+            }
+        }
+
+        // No local equivilant
+        return 0;
+    }
+
+    UiaPropertyId UiaGuid::LookupPropertyId()
+    {
+    if (ShouldUseRemoteApi())
+        {
+            ToRemote();
+            auto remoteValue = std::get_if<RemoteType>(&m_member);
+            if (remoteValue)
+            {
+                return remoteValue->LookupPropertyId();
+            }
+        }
+
+        // No local equivilant
+        return 0;
+    }
+
+    void UiaGuid::FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result)
+    {
+        m_member = winrt::unbox_value<GUID>(result);
+    }
+
+
     namespace impl
     {
         template <>
@@ -1008,6 +1078,17 @@ namespace UiaOperationAbstraction
         }
     }
 
+    void UiaOperationDelegator::ConvertVariantDataToRemote(std::variant<winrt::guid,
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteGuid>& localGuidVariant) const
+    {
+        if (m_useRemoteApi && m_remoteOperation)
+        {
+            if (auto localGuid = std::get_if<winrt::guid>(&localGuidVariant))
+            {
+                localGuidVariant = m_remoteOperation.NewGuid(*localGuid);
+            }
+        }
+    }
 
 
     UiaBool::UiaBool(bool value):

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -718,8 +718,8 @@ namespace UiaOperationAbstraction
             }
         }
 
-        // No local equivilant
-        return 0;
+        GUID localValue = std::get<LocalType>(m_member);
+        return UiaLookupId(AutomationIdentifierType_Annotation, &localValue);
     }
 
     UiaPropertyId UiaGuid::LookupPropertyId()
@@ -734,8 +734,8 @@ namespace UiaOperationAbstraction
             }
         }
 
-        // No local equivilant
-        return 0;
+        GUID localValue = std::get<LocalType>(m_member);
+        return UiaLookupId(AutomationIdentifierType_Property, &localValue);
     }
 
     void UiaGuid::FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result)

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -2196,6 +2196,7 @@ namespace UiaOperationAbstraction
         UiaBool operator!=(const UiaGuid& rhs) const;
         UiaAnnotationType LookupAnnotationType();
         UiaPropertyId LookupPropertyId();
+        operator winrt::guid() const; 
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
     };
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -413,6 +413,9 @@ namespace UiaOperationAbstraction
         void ConvertVariantDataToRemote(std::variant<
             winrt::com_ptr<IUIAutomationTextRange>,
             winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextRange>& localTextRangeVariant) const;
+        void ConvertVariantDataToRemote(std::variant<
+            winrt::guid,
+            winrt::Microsoft::UI::UIAutomation::AutomationRemoteGuid>& localGuidVariant) const;
 
         template <class ItemWrapperType>
         void ConvertVariantDataToRemote(std::variant<
@@ -2175,6 +2178,25 @@ namespace UiaOperationAbstraction
         void AddProperty(UiaPropertyId propertyId);
         void AddPattern(UiaPatternId patternId);
     };
+
+    class UiaGuid : public UiaTypeBase<winrt::guid, winrt::Microsoft::UI::UIAutomation::AutomationRemoteGuid>
+    {
+    public:
+        //static constexpr VARTYPE c_comVariantType = VT_CLSID;
+        //static constexpr auto c_variantMember = &VARIANT::puuid;
+        static constexpr auto c_anyTest = &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::IsGuid;
+        static constexpr auto c_anyCast = &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsGuid;
+        UiaGuid(const winrt::guid& value);
+        UiaGuid(winrt::Microsoft::UI::UIAutomation::AutomationRemoteGuid remoteValue);
+        UiaGuid(winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject remoteValue);
+        UiaGuid& operator=(const UiaGuid& other);
+        UiaBool operator==(const UiaGuid& rhs) const;
+        UiaBool operator!=(const UiaGuid& rhs) const;
+        UiaAnnotationType LookupAnnotationType();
+        UiaPropertyId LookupPropertyId();
+        void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result);
+    };
+
 
 #include "UiaTypeAbstraction.g.h"
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -2186,8 +2186,6 @@ namespace UiaOperationAbstraction
     class UiaGuid : public UiaTypeBase<winrt::guid, winrt::Microsoft::UI::UIAutomation::AutomationRemoteGuid>
     {
     public:
-        //static constexpr VARTYPE c_comVariantType = VT_CLSID;
-        //static constexpr auto c_variantMember = &VARIANT::puuid;
         static constexpr auto c_anyTest = &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::IsGuid;
         static constexpr auto c_anyCast = &winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject::AsGuid;
         UiaGuid(const winrt::guid& value);

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.vcxproj
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.vcxproj
@@ -101,6 +101,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib>
+      <AdditionalDependencies>uiAutomationCore.lib</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -116,6 +119,9 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib>
+      <AdditionalDependencies>uiAutomationCore.lib</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -131,6 +137,9 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib>
+      <AdditionalDependencies>uiAutomationCore.lib</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -150,6 +159,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib>
+      <AdditionalDependencies>uiAutomationCore.lib</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
@@ -2163,7 +2163,7 @@
                 this->ToRemote();
                 guid.ToRemote();
                 auto remoteValue = std::get<winrt::Microsoft::UI::UIAutomation::AutomationRemoteElement>(m_member);
-                (args.ToRemote(),...); Beep(770,90);
+                (args.ToRemote(),...);
                 remoteValue.CallExtension(guid, {static_cast<winrt::Microsoft::UI::UIAutomation::AutomationRemoteObject>(args)...});
                 return;
             }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
@@ -2168,7 +2168,7 @@
                 return;
             }
 
-            // No local equivilant
+            // No local equivalent
             throw winrt::hresult_not_implemented();
         }
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
@@ -2164,7 +2164,7 @@
                 guid.ToRemote();
                 auto remoteValue = std::get<winrt::Microsoft::UI::UIAutomation::AutomationRemoteElement>(m_member);
                 (args.ToRemote(),...); Beep(770,90);
-                remoteValue.CallExtension(guid, {args...});
+                remoteValue.CallExtension(guid, {static_cast<winrt::Microsoft::UI::UIAutomation::AutomationRemoteObject>(args)...});
                 return;
             }
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstraction.g.h
@@ -2154,6 +2154,24 @@
 
         UiaVariant GetMetadataValue(UiaPropertyId propertyId, UiaMetadata metadataId);
 
+        UiaBool IsExtensionSupported(UiaGuid guid);
+
+        template<typename... ArgTypes> void CallExtension(UiaGuid guid, ArgTypes&... args)
+        {
+            if (UiaOperationAbstraction::ShouldUseRemoteApi())
+            {
+                this->ToRemote();
+                guid.ToRemote();
+                auto remoteValue = std::get<winrt::Microsoft::UI::UIAutomation::AutomationRemoteElement>(m_member);
+                (args.ToRemote(),...); Beep(770,90);
+                remoteValue.CallExtension(guid, {args...});
+                return;
+            }
+
+            // No local equivilant
+            throw winrt::hresult_not_implemented();
+        }
+
         void FromRemoteResult(const winrt::Windows::Foundation::IInspectable& result)
         {
             m_member = result.as<IUIAutomationElement>();

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
@@ -7223,3 +7223,17 @@
 
         return metadataValue;
     }
+
+    UiaBool UiaElement::IsExtensionSupported(UiaGuid guid)
+    {
+        if (UiaOperationAbstraction::ShouldUseRemoteApi())
+        {
+            this->ToRemote();
+            guid.ToRemote();
+            auto remoteValue = std::get<winrt::Microsoft::UI::UIAutomation::AutomationRemoteElement>(m_member);
+            return remoteValue.IsExtensionSupported(guid);
+        }
+
+        // No local equivilant
+        throw winrt::hresult_not_implemented();
+    } 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
@@ -7234,6 +7234,6 @@
             return remoteValue.IsExtensionSupported(guid);
         }
 
-        // No local equivilant
+        // No local equivalent
         throw winrt::hresult_not_implemented();
     } 


### PR DESCRIPTION
UI Automation recently introduced the concept of custom patterns. This is the ability for a provider to expose custom methods, identified by a GUID, that a client an execute via UIA remote Operations. For example, MS Word might expose a custom pattern for moving by sentence - something that UIA by itself does not support.

This PR implements the ability for a client to execute these custom methods (extensions) by using the UIA Operation Abstraction library. Support for custom patterns has already been introduced to the Microsoft::UI::UIAutomation winrt library.

Specific changes:
* Added a new UiaGuid class, which represents either a local or remote GUID.
	* It can be constructed locally from a winrt::guid.
	* It can be assigned to, and compaired with == / !=.
	* It exposes LookupAnnotationType and LookupPropertyId methods, which work both remotely and locally.
* Implement UiaElement::IsExtensionSupported: this method takes a UiaGuid as an argument, and returns a UiaBool denoting if the extension identified by the given GUID is supported by the remote provider.
	* If remote, this method calls AutomationRemoteElement::IsExtensionSupported.
	* This method has no local equivilant and therefore throws NotImplemented if executed locally.
* Implemented UiaElement::CallExtension: this method takes a UiaGuid, plus a variable number of further arguments of any Uia* type, and executes the extension identified by the given GUID, passing the given arguments as its in/out arguments.
	* If remote, this method calls AutomationRemoteElement::CallExtension.
	* This method has no local equivilant and therefore throws NotImplemented if executed locally. 

No tests have been written yet. These will be hard to write unless they can be run against a specific app that exposes 1 or more custom patterns. 
Manually I have tested UiaGuid::LookupAnnotationType / UiaGuid::LookupPropertyId. But I am so far unable to test UiaElement::IsExtensionSupported / UIAElement::CallExtension until I have an app that actually implements 1 or more custom patterns...  