### PR TITLE
Allow tests to successfully run on Windows 11 (handling new Calculator UI)

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -414,9 +414,17 @@ namespace UiaOperationAbstractionTests
             cacheRequest.AddProperty(UIA_NamePropertyId);
             cacheRequest.AddPattern(UIA_TextPatternId);
 
+            auto parent = element.GetParentElement();
+            // New versions of Calculator have an extra ancestor element (with custom controlType) between the grouping and the first Window element.
+            // Skip over this if found.
+            scope.If(
+                parent.GetParentElement().GetControlType() == UIA_CustomControlTypeId,
+                [&]() { parent = parent.GetParentElement(); }
+            );
+
             // Get the parent of the parent, since this should be the window element.
-            auto uncachedParent = element.GetParentElement().GetParentElement();
-            auto cachedParent = element.GetParentElement().GetParentElement(cacheRequest);
+            auto uncachedParent = parent.GetParentElement();
+            auto cachedParent = parent.GetParentElement(cacheRequest);
             scope.BindResult(uncachedParent);
             scope.BindResult(cachedParent);
 
@@ -493,7 +501,12 @@ namespace UiaOperationAbstractionTests
                 },
                 [&]() // body
                 {
-                    parentChain.Append(element);
+                    // New versions of Calculator have an extra ancestor element (with custom controlType) between the display and window element.
+                    // Don't include this in the collected ancestors
+                    scope.If(
+                        element.GetControlType() != UIA_CustomControlTypeId,
+                        [&]() { parentChain.Append(element); }
+                    );
                     // The last element we get should be Null here, we are testing wrapper implementation
                     // could make sure the whole operation won't abort due to this.
                     UiaElement parent = element.GetParentElement(cacheRequest);
@@ -2564,6 +2577,156 @@ namespace UiaOperationAbstractionTests
         TEST_METHOD(IsOpcodeSupported_BeforeImport_Local)
         {
             IsOpcodeSupportedTest_BeforeImport(false);
+        }
+
+        // Test equality of UiaGuid objects.
+        void UiaGuidEqualityTest(const bool useRemoteOperations)
+        {
+            auto guard = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+            auto calc = WaitForElementFocus(L"Display is 0");
+            UiaElement element = calc;
+
+            auto scope = UiaOperationScope::StartNew();
+            scope.BindInput(element);
+
+            // Some UiaGuids from actual local GUID values
+            UiaGuid nameGuid{Name_Property_GUID};
+            UiaGuid controlTypeGuid{ControlType_Property_GUID};
+
+            // Find out if these UiaGuids are equal or not,
+            // They should b different
+            auto areNameAndControlTypeGuidsSame = nameGuid == controlTypeGuid;
+            scope.BindResult(areNameAndControlTypeGuidsSame);
+            auto areNameAndControlTypeGuidsDifferent = nameGuid != controlTypeGuid;
+            scope.BindResult(areNameAndControlTypeGuidsDifferent);
+
+            // Make copies of these UiaGuids
+            // Deliberately initializing with a NULL guid and then copying by assignment, not constructing by reference,
+            // As we do want them to be physically different objects.
+            winrt::guid GUID_NULL{0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}};
+            UiaGuid nameGuid_copy{GUID_NULL};
+            nameGuid_copy = nameGuid;
+            scope.BindResult(nameGuid_copy);
+            UiaGuid controlTypeGuid_copy{GUID_NULL};
+            controlTypeGuid_copy = controlTypeGuid;
+            scope.BindResult(controlTypeGuid_copy);
+
+            //Find out if the original and its copy are equal.
+            // They should be.
+            auto areNameGuidAndCopySame = nameGuid == nameGuid_copy;
+            scope.BindResult(areNameGuidAndCopySame);
+            auto areNameGuidAndCopyDifferent = nameGuid != nameGuid_copy;
+            scope.BindResult(areNameGuidAndCopyDifferent);
+
+            // Find out if the copies are different from each other,
+            // They should be.
+            auto areGuidCopiesSame = nameGuid_copy == controlTypeGuid_copy;
+            scope.BindResult(areGuidCopiesSame);
+            auto areGuidCopiesDifferent = nameGuid_copy != controlTypeGuid_copy;
+            scope.BindResult(areGuidCopiesDifferent);
+
+            // Actually execute
+            scope.Resolve();
+
+            // Assert all our remote findings
+            Assert::IsFalse(areNameAndControlTypeGuidsSame);
+            Assert::IsTrue(areNameAndControlTypeGuidsDifferent);
+            Assert::IsTrue(areNameGuidAndCopySame);
+            Assert::IsFalse(areNameGuidAndCopyDifferent);
+            Assert::IsFalse(areGuidCopiesSame);
+            Assert::IsTrue(areGuidCopiesDifferent);
+
+            // Make a new local GUID from one of the generated copies,
+            // And ensure it holds the correct GUID value
+            winrt::guid nameGuid_final = nameGuid_copy;
+            Assert::IsTrue(IsEqualGUID(nameGuid_final, Name_Property_GUID));
+        }
+
+        TEST_METHOD(UiaGuidEquality_Remote)
+        {
+            UiaGuidEqualityTest(true);
+        }
+
+        TEST_METHOD(UiaGuidEquality_Local)
+        {
+            UiaGuidEqualityTest(false);
+        }
+
+        // UiaGuid: test looking up property IDs
+        void UiaGuidLookupPropertyIdTest(const bool useRemoteOperations)
+        {
+            auto guard = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+            auto calc = WaitForElementFocus(L"Display is 0");
+            UiaElement element = calc;
+
+            auto scope = UiaOperationScope::StartNew();
+            scope.BindInput(element);
+
+            UiaGuid propGuid{Name_Property_GUID};
+            auto propId = propGuid.LookupPropertyId();
+
+            auto isNamePropertyId = propId == UiaPropertyId(UIA_NamePropertyId);
+            scope.BindResult(isNamePropertyId);
+            auto isControlTypePropertyId = propId == UiaPropertyId(UIA_ControlTypePropertyId);
+            scope.BindResult(isControlTypePropertyId);
+
+            scope.Resolve();
+
+            Assert::IsTrue(isNamePropertyId);
+            Assert::IsFalse(isControlTypePropertyId);
+        }
+
+        TEST_METHOD(UiaGuidLookupPropertyId_Remote)
+        {
+            UiaGuidLookupPropertyIdTest(true);
+        }
+
+        TEST_METHOD(UiaGuidLookupPropertyId_Local)
+        {
+            UiaGuidLookupPropertyIdTest(false);
+        }
+
+        // UiaGuid: test looking up annotation type IDs 
+        void UiaGuidLookupAnnotationTypeIdTest(const bool useRemoteOperations)
+        {
+            auto guard = InitializeUiaOperationAbstraction(useRemoteOperations);
+
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+            auto calc = WaitForElementFocus(L"Display is 0");
+            UiaElement element = calc;
+
+            auto scope = UiaOperationScope::StartNew();
+            scope.BindInput(element);
+
+            UiaGuid annotationTypeGuid{Annotation_SpellingError_GUID};
+            auto annotationTypeId = annotationTypeGuid.LookupAnnotationType();
+
+            auto isSpellingErrorAnnotationTypeId = annotationTypeId == UiaAnnotationType(AnnotationType_SpellingError);
+            scope.BindResult(isSpellingErrorAnnotationTypeId);
+            auto isCommentAnnotationTypeId = annotationTypeId == UiaAnnotationType(AnnotationType_Comment);
+            scope.BindResult(isCommentAnnotationTypeId);
+
+            scope.Resolve();
+
+            Assert::IsTrue(isSpellingErrorAnnotationTypeId);
+            Assert::IsFalse(isCommentAnnotationTypeId);
+        }
+
+        TEST_METHOD(UiaGuidLookupAnnotationTypeId_Remote)
+        {
+            UiaGuidLookupAnnotationTypeIdTest(true);
+        }
+
+        TEST_METHOD(UiaGuidLookupAnnotationTypeId_Local)
+        {
+            UiaGuidLookupAnnotationTypeIdTest(false);
         }
     };
 }

--- a/src/UIAutomation/FunctionalTests/WinRTBuilderTests.cpp
+++ b/src/UIAutomation/FunctionalTests/WinRTBuilderTests.cpp
@@ -331,7 +331,14 @@ namespace WinRTBuilderTests
             cacheRequest.AddProperty(op.NewEnum(static_cast<winrt::AutomationPropertyId>(UIA_NamePropertyId)));
             cacheRequest.AddPattern(op.NewEnum(static_cast<winrt::AutomationPatternId>(UIA_TextPatternId)));
 
-            const auto window = remoteCalc.GetParentElement().GetParentElement();
+            auto window = remoteCalc.GetParentElement().GetParentElement();
+            // Newer versions of Calculator have an extra ancestor element (with custom controlType) between the grouping element and the Window element.
+            // So keep walking until we get to the Window element.
+            op.IfBlock(
+                window.GetPropertyValue(op.NewEnum(winrt::AutomationPropertyId::ControlType)).AsControlType().IsEqual(op.NewEnum(winrt::AutomationControlType::Custom)),
+                [&]() { window.Set(window.GetParentElement()); }
+            );
+            
             window.PopulateCache(cacheRequest);
             const auto windowToken = op.RequestResponse(window);
 
@@ -371,7 +378,14 @@ namespace WinRTBuilderTests
             cacheRequest.AddProperty(op.NewEnum(static_cast<winrt::AutomationPropertyId>(UIA_NamePropertyId)));
             cacheRequest.AddPattern(op.NewEnum(static_cast<winrt::AutomationPatternId>(UIA_TextPatternId)));
 
-            const auto window = remoteCalc.GetParentElement().GetParentElement();
+            auto window = remoteCalc.GetParentElement().GetParentElement();
+            // Newer versions of Calculator have an extra ancestor element (with custom controlType) between the grouping element and the Window element.
+            // So keep walking until we get to the Window element.
+            op.IfBlock(
+                window.GetPropertyValue(op.NewEnum(winrt::AutomationPropertyId::ControlType)).AsControlType().IsEqual(op.NewEnum(winrt::AutomationControlType::Custom)),
+                [&]() { window.Set(window.GetParentElement()); }
+            );
+
             window.PopulateCache(cacheRequest);
             const auto windowToken = op.RequestResponse(window);
 


### PR DESCRIPTION
## problem
The majority of the functional tests for the microsoft-ui-uiAutomation project use the Calculator modern app, in-built to Windows.  But due to changes to the Calculator's UI on Windows 11, several of the tests fail, making it impossible to successfully run all tests on Windows 11.
Specifically, the Calculator app now has an extra ancestor element (with a custom controlType) between the grouping element and the window element.
 
## Solution
Changed the affected tests to detect and skip over the new Custom element if found.

## Testing performed
Successfully ran all functional tests on Windows 11 build 22572, Calculator version 11.2201.4.0.