### PR TITLE
scope::resolve throws more meaningful exceptions for statuses such as instructionLimitExceeded

### DIFF
--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -2757,6 +2757,38 @@ namespace UiaOperationAbstractionTests
             LogOutput(L"x = ",static_cast<int>(x));
         }
 
+        // Test that creating a remote operation that is too large raises a MalformedByteCodeException
+        TEST_METHOD(ResolveThrowsMalformedBytecodeException)
+        {
+            auto guard = InitializeUiaOperationAbstraction(true);
+
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+            auto calc = WaitForElementFocus(L"Display is 0");
+
+            auto scope = UiaOperationScope::StartNew();
+
+            UiaElement element = calc;
+
+            for(auto i=0; i<200000; ++i)
+            {
+                UiaBool b{true};
+            }
+
+            Assert::ExpectException<MalformedBytecodeException>([&]()
+            {
+                try
+                {
+                    scope.Resolve();
+                }
+                catch(winrt::hresult_error& e)
+                {
+                    Assert::AreEqual(E_FAIL, static_cast<HRESULT>(e.code()));
+                    throw;
+                }
+            });
+        }
+
         // Test that  a runtime error within a remote operation causes an UnhandledRemoteException in resolve.
         TEST_METHOD(ResolveThrowsUnhandledRemoteException)
         {

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -2717,7 +2717,7 @@ namespace UiaOperationAbstractionTests
         }
 
         // Test that hitting the instruction limit in a remote operation causes an InstructionLimitExceededException in resolve.
-        TEST_METHOD(instructionLimitExceeded)
+        TEST_METHOD(ResolveThrowsInstructionLimitExceededException)
         {
             auto guard = InitializeUiaOperationAbstraction(true);
 
@@ -2758,7 +2758,7 @@ namespace UiaOperationAbstractionTests
         }
 
         // Test that  a runtime error within a remote operation causes an UnhandledRemoteException in resolve.
-        TEST_METHOD(unhandledRemoteException)
+        TEST_METHOD(ResolveThrowsUnhandledRemoteException)
         {
             auto guard = InitializeUiaOperationAbstraction(true);
 
@@ -2788,8 +2788,8 @@ namespace UiaOperationAbstractionTests
             });
         }
 
-        // Test that  a execution failure within a remote operation causes an ExecutionFailureException in resolve.
-        TEST_METHOD(executionFailureException)
+        // Test that  an execution failure within a remote operation causes an ExecutionFailureException in resolve.
+        TEST_METHOD(ResolveThrowsExecutionFailureException)
         {
             auto guard = InitializeUiaOperationAbstraction(true);
 

--- a/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
+++ b/src/UIAutomation/FunctionalTests/UiaOperationAbstractionTests.cpp
@@ -2715,5 +2715,113 @@ namespace UiaOperationAbstractionTests
         {
             UiaGuidLookupAnnotationTypeIdTest(false);
         }
+
+        // Test that hitting the instruction limit in a remote operation causes an InstructionLimitExceededException in resolve.
+        TEST_METHOD(instructionLimitExceeded)
+        {
+            auto guard = InitializeUiaOperationAbstraction(true);
+
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+            auto calc = WaitForElementFocus(L"Display is 0");
+
+            auto scope = UiaOperationScope::StartNew();
+
+            UiaElement element = calc;
+
+            UiaInt x{0};
+            UiaBool keepRunning{true};
+
+            scope.While(
+                [&]() { return keepRunning; },
+                [&]() { x += 1; }
+            );
+
+            scope.BindResult(x);
+
+            Assert::ExpectException<InstructionLimitExceededException>([&]()
+            {
+                try
+                {
+                    scope.Resolve();
+                }
+                catch(winrt::hresult_error& e)
+                {
+                    Assert::AreEqual(E_FAIL, static_cast<HRESULT>(e.code()));
+                    throw;
+                }
+            });
+
+            // And we can still access the calculated results so far
+            Assert::AreEqual(static_cast<int>(x) > 0, true);
+            LogOutput(L"x = ",static_cast<int>(x));
+        }
+
+        // Test that  a runtime error within a remote operation causes an UnhandledRemoteException in resolve.
+        TEST_METHOD(unhandledRemoteException)
+        {
+            auto guard = InitializeUiaOperationAbstraction(true);
+
+            ModernApp app(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app.Activate();
+            auto calc = WaitForElementFocus(L"Display is 0");
+
+            auto scope = UiaOperationScope::StartNew();
+
+            UiaElement element = calc;
+
+            UiaArray<UiaInt> a;
+            // Accessing an element of an empty array should cause an E_BOUNDS error
+            auto x = a.GetAt(0);
+
+            Assert::ExpectException<UnhandledRemoteException>([&]()
+            {
+                try
+                {
+                    scope.Resolve();
+                }
+                catch(winrt::hresult_error& e)
+                {
+                    Assert::AreEqual(E_BOUNDS, static_cast<HRESULT>(e.code()));
+                    throw;
+                }
+            });
+        }
+
+        // Test that  a execution failure within a remote operation causes an ExecutionFailureException in resolve.
+        TEST_METHOD(executionFailureException)
+        {
+            auto guard = InitializeUiaOperationAbstraction(true);
+
+            ModernApp app1(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app1.Activate();
+            auto calc1 = WaitForElementFocus(L"Display is 0");
+
+            ModernApp app2(L"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App");
+            app2.Activate();
+            auto calc2 = WaitForElementFocus(L"Display is 0");
+            
+            auto scope = UiaOperationScope::StartNew();
+
+            UiaElement element1 = calc1;
+            UiaElement element2 = calc2;
+            UiaBool sameNames = element1.GetName() == element2.GetName();
+            scope.BindResult(sameNames);
+
+            // As this operation deals with elements from 2 different processes
+            // resolving will cause an execution failure.
+            Assert::ExpectException<ExecutionFailureException>([&]()
+            {
+                try
+                {
+                    scope.Resolve();
+                }
+                catch(winrt::hresult_error& e)
+                {
+                    Assert::AreEqual(E_UNEXPECTED, static_cast<HRESULT>(e.code()));
+                    throw;
+                }
+            });
+        }
     };
 }

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperationResultSet.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperationResultSet.cpp
@@ -26,6 +26,16 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         }
     }
 
+    winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus AutomationRemoteOperationResultSet::Status()
+    {
+        return m_result.Status();
+    }
+
+    winrt::hresult AutomationRemoteOperationResultSet::ExtendedError()
+    {
+        return m_result.ExtendedError();
+    }
+
     bool AutomationRemoteOperationResultSet::HasResult(Microsoft::UI::UIAutomation::AutomationRemoteOperationResponseToken const& token)
     {
         return m_result.HasOperand({ token.Value });

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperationResultSet.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperationResultSet.h
@@ -39,6 +39,10 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
 
         winrt::hresult OperationStatus();
 
+        winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus Status();
+
+        winrt::hresult ExtendedError();
+
         bool HasResult(winrt::AutomationRemoteOperationResponseToken const& token);
         winrt::IInspectable GetResult(winrt::AutomationRemoteOperationResponseToken const& token);
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import "Windows.Foundation.idl";
+import "Windows.UI.UIAutomation.core.idl";
 import "Windows.UI.UIAutomation.idl";
 
 namespace Microsoft.UI.UIAutomation
@@ -184,8 +185,11 @@ namespace Microsoft.UI.UIAutomation
 
     runtimeclass AutomationRemoteOperationResultSet
     {
+        // The following method is deprecated.
+        // Use Status or ExtendedError instead.
         HRESULT OperationStatus{ get; };
-
+        Windows.UI.UIAutomation.Core.AutomationRemoteOperationStatus Status{ get; };
+        HRESULT ExtendedError{ get; };
         Boolean HasResult(AutomationRemoteOperationResponseToken token);
         IInspectable GetResult(AutomationRemoteOperationResponseToken token);
     }

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -2316,9 +2316,7 @@ namespace UiaOperationAbstraction
 
     void UiaOperationScope::Resolve()
     {
-        auto status = winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::Success;
-        HRESULT extendedError = S_OK;
-        ResolveInternal(status, extendedError);
+                auto [status, extendedError] = ResolveInternal();
         switch(status)
         {
             case winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::MalformedBytecode:
@@ -2336,17 +2334,15 @@ namespace UiaOperationAbstraction
 
     [[nodiscard]] HRESULT UiaOperationScope::ResolveHr() noexcept try
     {
-        auto status = winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::Success;
-        HRESULT extendedError = S_OK;
-        ResolveInternal(status, extendedError);
+        auto [status, extendedError] = ResolveInternal();
         return extendedError;
     }
     CATCH_RETURN();
   
-    void UiaOperationScope::ResolveInternal(winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus& status, HRESULT& extendedError)
+    std::pair<winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus, HRESULT> UiaOperationScope::ResolveInternal()
     {
-        status = winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::Success;
-        extendedError = S_OK;
+        auto status = winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::Success;
+        HRESULT extendedError = S_OK;
 
         // Resolve does nothing if we don't own the current context. 
         if (m_ownContext)
@@ -2391,7 +2387,8 @@ namespace UiaOperationAbstraction
             s_scopeContextManager.Get().PopContext();
             m_ownContext = false;
         }
-    }   
+        return {status, extendedError};
+    }
 
     UiaOperationScope UiaOperationScope::StartNew()
     {

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -2371,7 +2371,7 @@ namespace UiaOperationAbstraction
 
                 // Fetch bound results on success, but also
                 // instruction limit exceeded, 
-                // As we no certainly some of the remote operation did execute.
+                // As we know certainly some of the remote operation did execute.
                 if (
                     status == winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::Success
                     || status == winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::InstructionLimitExceeded

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -2316,7 +2316,7 @@ namespace UiaOperationAbstraction
 
     void UiaOperationScope::Resolve()
     {
-                auto [status, extendedError] = ResolveInternal();
+        auto [status, extendedError] = ResolveInternal();
         switch(status)
         {
             case winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::MalformedBytecode:

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -2322,15 +2322,15 @@ namespace UiaOperationAbstraction
         switch(status)
         {
             case winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::MalformedBytecode:
-            throw MalformedBytecodeException(extendedError);
+                throw MalformedBytecodeException(extendedError);
             case winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::InstructionLimitExceeded:
-            throw InstructionLimitExceededException(extendedError);
+                throw InstructionLimitExceededException(extendedError);
             case winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::UnhandledException:
-            throw UnhandledRemoteException(extendedError);
+                throw UnhandledRemoteException(extendedError);
             case winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::ExecutionFailure:
-            throw ExecutionFailureException(extendedError);
+                throw ExecutionFailureException(extendedError);
             default:
-            THROW_IF_FAILED(extendedError);
+                THROW_IF_FAILED(extendedError);
         }
     }
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -2650,7 +2650,7 @@ namespace UiaOperationAbstraction
         template<class Body>
         void While(UiaBool&&, Body body) = delete;
 
-        void ResolveInternal(winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus& status, HRESULT& extendedError);
+        std::pair<winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus, HRESULT> ResolveInternal();
 
     };
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -71,6 +71,34 @@ namespace UiaOperationAbstraction
         const char* what() const override { return "RemoteOperationsWrapper local loop break"; }
     };
 
+    class ExecutionFailureException: public winrt::hresult_error {
+        public:
+        ExecutionFailureException(const HRESULT code): winrt::hresult_error(code)
+        {
+        }
+    };
+
+    class UnhandledRemoteException: public winrt::hresult_error {
+        public:
+        UnhandledRemoteException(const HRESULT code): winrt::hresult_error(code)
+        {
+        }
+    };
+
+    class MalformedBytecodeException: public winrt::hresult_error {
+        public:
+        MalformedBytecodeException(const HRESULT code): winrt::hresult_error(code)
+        {
+        }
+    };
+
+    class InstructionLimitExceededException: public winrt::hresult_error {
+        public:
+        InstructionLimitExceededException(const HRESULT code): winrt::hresult_error(code)
+        {
+        }
+    };
+
     class UiaFailure
     {
     public:
@@ -2622,7 +2650,7 @@ namespace UiaOperationAbstraction
         template<class Body>
         void While(UiaBool&&, Body body) = delete;
 
-        void ResolveHrInternal(HRESULT& operationResult);
+        void ResolveInternal(winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus& status, HRESULT& extendedError);
 
     };
 


### PR DESCRIPTION
Fixes #87

The following new exceptions are thrown by UiaOperationScope::Resolve due to their respective operation result status values:
* ExecutionFailureException
* MalformedBytecodeException
* UnhandledRemoteException
* InstructionLimitExceededException

These new exceptions all inherit from winrt::hresult_error, so existing code that is catching winrt::result_error will still function exactly the same way.

Further to this, if InstructionLimitExceededException is thrown, any result variables already calculated before the limit was hit will be still resolved, making them available locally. 

These changes make it technically possible now to write remoted algorithms with the abstraction library, such that they could be continued on in a second remote call, if the first failed with an InstructionLimitExceeded exception, as result variables could be used to keep track of the state of the algorithm.
Also, all changes have been made to be fully compatible with previous code.

In order to make all this work, several other changes needed to be made.

The low-level winrt API's AutomationRemoteOperationResultSet::OperationStatus method was problematic as it essentially just returned the ExtendedError value, but tweaked for certain status values. E.g. E_FAIL was returned for InstructionLimitExceeded. This then meant that higher-level APIs could never access the actual OperationStatus value.
Therefore, the AutomationRemoteOperationResultSet class has the following changes:
* Added a Status method, which returns the raw AutomationRemoteOperationStatus value of the result. E.g. success, MalformedBytecodeInstruction, UnhandledException, ExecutionFailure. 
* Added an ExtendedError method, which returns the ExtendedError HRESULT value.
* Added a comment to the OperationStatus method noting it should be deprecated in favor of the separate Status and ExtendedError methods.
 
The high-level abstraction library's UiaOperationScope::ResultInternal now fetches Status and ExtendedError separately, rather than calling the old OperationStatus method. It then gives both of these values back by reference.
However, to ensure compatibility for higher-level APIs, extendedError is forced to E_FAIL if the status is InstructionLimitExceeded. Note that not doing this, ExtendedError would be S_OK. 

ResultInternal also now resolves all available result variables when the status is InstructionLimitExceeded, not just when the status is Success.

The high-level abstraction library's UiaOperationScope::ResolveHr method now returns the ExtendedError from ResolveInternal. But from the caller's point of view, there is no change at all.
 
The high-level abstraction library's UiaOperationScope::Resolve method now calls ResolveInternal directly, rather than ResolveHr. This is so it gets access to both the raw status and ExtendedError.
Based on the Status, Resolve throws the appropriate Exception, instantiated with the ExtendedError as its HRESULT error code.

Finally, tests have been added:
* executionFailureException: Testing that this exception is thrown by trying to execute a remote operation interacting with elements from more than one process. 
* UnhandledRemoteException: Testing that this exception is thrown by trying to fetch the first element from an empty UiaArray.
* InstructionLimitExceededException: Testing that this exception is thrown by constantly incrementing a UiaInt until the instruction limit is hit. 

I was not able to come up with any way of testing MalformedBytecodeException - the winrt and abstraction APIs should never allow a caller to produce this situation anyway I think.