### PR TITLE
Implement wrappers for CustomExtensions

### DIFF
--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteAnyObjectMethods.g.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteAnyObjectMethods.g.h
@@ -36,6 +36,7 @@
         winrt::AutomationRemoteTextPattern AsTextPattern();
         winrt::AutomationRemoteBool IsTextRange();
         winrt::AutomationRemoteTextRange AsTextRange();
+        winrt::AutomationRemoteConnectionBoundObject AsConnectionBoundObject();
         winrt::AutomationRemoteBool IsTogglePattern();
         winrt::AutomationRemoteTogglePattern AsTogglePattern();
         winrt::AutomationRemoteBool IsTransformPattern();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperation.h
@@ -66,6 +66,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteArray NewArray();
         winrt::AutomationRemoteStringMap NewStringMap();
         winrt::AutomationRemoteAnyObject NewNull();
+        winrt::AutomationRemoteAnyObject NewEmpty();
+        winrt::AutomationRemoteByteArray NewByteArray(winrt::array_view<const uint8_t> initialValue);
 
         // Returns whether the given opcode is supported in the current remote
         // operation connection. Calls directly into the corresponding
@@ -76,6 +78,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
 
         winrt::AutomationRemoteElement ImportElement(winrt::Windows::UI::UIAutomation::AutomationElement const& element);
         winrt::AutomationRemoteTextRange ImportTextRange(winrt::Windows::UI::UIAutomation::AutomationTextRange const& textRange);
+        winrt::AutomationRemoteConnectionBoundObject ImportConnectionBoundObject(winrt::Windows::UI::UIAutomation::AutomationConnectionBoundObject const& connectionBoundObject);
 
         AutomationRemoteOperationResponseToken RequestResponse(const winrt::AutomationRemoteObject& object);
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Client.g.cpp
@@ -3283,6 +3283,11 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return As<AutomationRemoteTextRange>();
     }
 
+    winrt::AutomationRemoteConnectionBoundObject AutomationRemoteAnyObject::AsConnectionBoundObject()
+    {
+        return As<AutomationRemoteConnectionBoundObject>();
+    }
+
     winrt::AutomationRemoteBool AutomationRemoteAnyObject::IsTogglePattern()
     {
         throw hresult_not_implemented();

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -144,6 +144,7 @@ namespace Microsoft.UI.UIAutomation
 
     unsealed runtimeclass AutomationRemoteExtensionTarget : AutomationRemoteObject
     {
+        AutomationRemoteBool IsExtensionTarget();
         void CallExtension(AutomationRemoteGuid extensionId, AutomationRemoteObject[] operands);
         AutomationRemoteBool IsExtensionSupported(AutomationRemoteGuid extensionId);
     }
@@ -176,6 +177,11 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteAnyObject Lookup(AutomationRemoteString key);
 
         AutomationRemoteUint Size();
+    };
+
+    runtimeclass AutomationRemoteByteArray : AutomationRemoteObject
+    {
+        void Set(AutomationRemoteByteArray rhs);
     };
 
     struct AutomationRemoteOperationResponseToken
@@ -260,6 +266,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteElement AsElement();
         AutomationRemoteBool IsCacheRequest();
         AutomationRemoteCacheRequest AsCacheRequest();
+        AutomationRemoteBool IsByteArray();
+        AutomationRemoteByteArray AsByteArray();
     }
 
     enum AutomationActiveEnd
@@ -1307,6 +1315,11 @@ namespace Microsoft.UI.UIAutomation
         void ShowContextMenu();
     };
 
+    runtimeclass AutomationRemoteConnectionBoundObject : AutomationRemoteExtensionTarget
+    {
+        void Set(AutomationRemoteConnectionBoundObject rhs);
+    };
+
     runtimeclass AutomationRemoteTextPattern : AutomationRemoteObject
     {
         void Set(AutomationRemoteTextPattern rhs);
@@ -1597,6 +1610,7 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteTextPattern AsTextPattern();
         AutomationRemoteBool IsTextRange();
         AutomationRemoteTextRange AsTextRange();
+        AutomationRemoteConnectionBoundObject AsConnectionBoundObject();
         AutomationRemoteBool IsTogglePattern();
         AutomationRemoteTogglePattern AsTogglePattern();
         AutomationRemoteBool IsTransformPattern();
@@ -1763,6 +1777,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteArray NewArray();
         AutomationRemoteStringMap NewStringMap();
         AutomationRemoteAnyObject NewNull();
+        AutomationRemoteAnyObject NewEmpty();
+        AutomationRemoteByteArray NewByteArray(byte[] initialValue);
 
         Boolean IsOpcodeSupported(UInt32 opcode);
 
@@ -1801,5 +1817,7 @@ namespace Microsoft.UI.UIAutomation
         void ReturnOperationStatus(AutomationRemoteInt status);
 
         AutomationRemoteOperationResultSet Execute();
+
+        AutomationRemoteConnectionBoundObject ImportConnectionBoundObject(Windows.UI.UIAutomation.AutomationConnectionBoundObject connectionBoundObject);
     }
 }

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
@@ -68,6 +68,11 @@ void RemoteOperationInstructionSerializer::Write(const GUID& value)
     m_builder.WriteGuid(value);
 }
 
+void RemoteOperationInstructionSerializer::Write(const uint8_t & value)
+{
+    m_builder.WriteByte(value);
+}
+
 void RemoteOperationInstructionSerializer::Serialize(const Instruction& genericInstruction)
 {
     std::visit([&](const auto& instruction)
@@ -507,6 +512,22 @@ void RemoteOperationInstructionSerializer::Write(const bytecode::IsExtensionSupp
     Write(instruction.resultId);
     Write(instruction.targetId);
     Write(instruction.extensionIdId);
+}
+
+void RemoteOperationInstructionSerializer::Write(const bytecode::IsExtensionTarget & instruction)
+{
+    Write(instruction.resultId);
+    Write(instruction.targetId);
+}
+
+void RemoteOperationInstructionSerializer::Write(const bytecode::NewByteArray & instruction)
+{
+    Write(instruction.resultId);
+    Write(static_cast<int>(instruction.initialValue.size()));
+    for (const auto& byteEntry : instruction.initialValue)
+    {
+        Write(byteEntry);
+    }
 }
 
 void RemoteOperationInstructionSerializer::Write(const GetterBase& instruction)

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
@@ -514,13 +514,13 @@ void RemoteOperationInstructionSerializer::Write(const bytecode::IsExtensionSupp
     Write(instruction.extensionIdId);
 }
 
-void RemoteOperationInstructionSerializer::Write(const bytecode::IsExtensionTarget & instruction)
+void RemoteOperationInstructionSerializer::Write(const bytecode::IsExtensionTarget& instruction)
 {
     Write(instruction.resultId);
     Write(instruction.targetId);
 }
 
-void RemoteOperationInstructionSerializer::Write(const bytecode::NewByteArray & instruction)
+void RemoteOperationInstructionSerializer::Write(const bytecode::NewByteArray& instruction)
 {
     Write(instruction.resultId);
     Write(static_cast<int>(instruction.initialValue.size()));

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.cpp
@@ -68,7 +68,7 @@ void RemoteOperationInstructionSerializer::Write(const GUID& value)
     m_builder.WriteGuid(value);
 }
 
-void RemoteOperationInstructionSerializer::Write(const uint8_t & value)
+void RemoteOperationInstructionSerializer::Write(const uint8_t& value)
 {
     m_builder.WriteByte(value);
 }

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructionSerialization.h
@@ -33,6 +33,7 @@ private:
     void Write(const UiaPoint& value);
     void Write(const UiaRect& value);
     void Write(const GUID& value);
+    void Write(const uint8_t& value);
 
     // Write the instructions themselves...
     void Write(const bytecode::Nop&);
@@ -116,6 +117,8 @@ private:
     void Write(const bytecode::Stringify&);
     void Write(const bytecode::CallExtension&);
     void Write(const bytecode::IsExtensionSupported&);
+    void Write(const bytecode::IsExtensionTarget&);
+    void Write(const bytecode::NewByteArray&);
 
     void Write(const bytecode::GetterBase&);
 #include "RemoteOperationInstructionSerializerMethods.g.h"

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructions.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/RemoteOperationInstructions.h
@@ -155,6 +155,10 @@ enum class InstructionType
     // Extensibility
     CallExtension = 0x53,
     IsExtensionSupported = 0x54,
+    IsExtensionTarget = 0x55,
+
+    NewByteArray = 0x56,
+    IsByteArray = 0x57,
 
     // UIA pattern getters and pattern methods
 #include "RemoteOperationInstructionEnumValues.g.h"
@@ -248,6 +252,9 @@ constexpr std::array c_supportedInstructions =
     InstructionType::GetMetadataValue,
     InstructionType::CallExtension,
     InstructionType::IsExtensionSupported,
+    InstructionType::IsExtensionTarget,
+    InstructionType::NewByteArray,
+    InstructionType::IsByteArray,
 
     // Auto-generated UIA pattern getters and pattern methods
 #include "RemoteOperationInstructionEnumValuesArray.g.h"
@@ -957,6 +964,27 @@ struct IsExtensionSupported
     OperandId extensionIdId;
 };
 
+struct IsExtensionTarget
+{
+    constexpr static InstructionType type = InstructionType::IsExtensionTarget;
+
+    OperandId resultId;
+    OperandId targetId;
+};
+
+struct NewByteArray
+{
+    constexpr static InstructionType type = InstructionType::NewByteArray;
+
+    OperandId resultId;
+    std::vector<uint8_t> initialValue;
+};
+
+struct IsByteArray : GetterBase
+{
+    constexpr static InstructionType type = InstructionType::IsByteArray;
+};
+
 #include "RemoteOperationInstructions.g.h"
 
 using Instruction = std::variant<
@@ -1018,6 +1046,7 @@ using Instruction = std::variant<
     NewNull,
     NewGuid,
     NewCacheRequest,
+    NewByteArray,
 
     // Point and Rect methods
     GetPointProperty,
@@ -1074,12 +1103,14 @@ using Instruction = std::variant<
     IsElement,
     IsGuid,
     IsCacheRequest,
+    IsByteArray,
 
     Stringify,
 
     // Provider Extension methods
     CallExtension,
-    IsExtensionSupported
+    IsExtensionSupported,
+    IsExtensionTarget
 
 #include "RemoteOperationInstructionsVariantParams.g.h"
     >;

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -564,13 +564,6 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return result;
     }
 
-    // AutomationRemoteConnectionBoundObject
-
-    AutomationRemoteConnectionBoundObject::AutomationRemoteConnectionBoundObject(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
-        : base_type(operandId, parent)
-    {
-    }
-
     // AutomationRemoteStringMap
 
     AutomationRemoteStringMap::AutomationRemoteStringMap(bytecode::OperandId operandId, AutomationRemoteOperation& parent) :
@@ -754,6 +747,13 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
             m_operandId,
             GetOperandId<AutomationRemoteCacheRequest>(cacheRequest)
         });
+    }
+
+    // AutomationRemoteConnectionBoundObject
+
+    AutomationRemoteConnectionBoundObject::AutomationRemoteConnectionBoundObject(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
+        : base_type(operandId, parent)
+    {
     }
 
     // AutomationRemoteAnyObject

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -529,8 +529,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         const auto resultId = m_parent->GetNextId();
         m_parent->InsertInstruction(bytecode::IsExtensionTarget{
             resultId,
-            m_operandId,
-            });
+            m_operandId
+        });
 
         const auto result = Make<AutomationRemoteBool>(resultId);
         return result;
@@ -998,7 +998,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         m_parent->InsertInstruction(bytecode::IsByteArray{
             resultId,
             m_operandId
-            });
+        });
 
         const auto result = Make<AutomationRemoteBool>(resultId);
         return result;

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -512,8 +512,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
 
     // AutomationRemoteByteArray
 
-    AutomationRemoteByteArray::AutomationRemoteByteArray(bytecode::OperandId operandId, AutomationRemoteOperation & parent)
-    : base_type(operandId, parent)
+    AutomationRemoteByteArray::AutomationRemoteByteArray(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
+        : base_type(operandId, parent)
     {
     }
 
@@ -528,9 +528,9 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     {
         const auto resultId = m_parent->GetNextId();
         m_parent->InsertInstruction(bytecode::IsExtensionTarget{
-        resultId,
-        m_operandId,
-        });
+            resultId,
+            m_operandId,
+            });
 
         const auto result = Make<AutomationRemoteBool>(resultId);
         return result;
@@ -566,8 +566,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
 
     // AutomationRemoteConnectionBoundObject
 
-    AutomationRemoteConnectionBoundObject::AutomationRemoteConnectionBoundObject(bytecode::OperandId operandId, AutomationRemoteOperation & parent)
-    : base_type(operandId, parent)
+    AutomationRemoteConnectionBoundObject::AutomationRemoteConnectionBoundObject(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
+        : base_type(operandId, parent)
     {
     }
 
@@ -996,9 +996,10 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     {
         const auto resultId = m_parent->GetNextId();
         m_parent->InsertInstruction(bytecode::IsByteArray{
-        resultId,
-        m_operandId
-        });
+            resultId,
+            m_operandId
+            });
+
         const auto result = Make<AutomationRemoteBool>(resultId);
         return result;
     }

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -510,11 +510,30 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return result;
     }
 
+    // AutomationRemoteByteArray
+
+    AutomationRemoteByteArray::AutomationRemoteByteArray(bytecode::OperandId operandId, AutomationRemoteOperation & parent)
+    : base_type(operandId, parent)
+    {
+    }
+
     // AutomationRemoteExtensionTarget
 
     AutomationRemoteExtensionTarget::AutomationRemoteExtensionTarget(bytecode::OperandId operandId, AutomationRemoteOperation& parent)
         : base_type(operandId, parent)
     {
+    }
+
+    winrt::AutomationRemoteBool AutomationRemoteExtensionTarget::IsExtensionTarget()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::IsExtensionTarget{
+        resultId,
+        m_operandId,
+        });
+
+        const auto result = Make<AutomationRemoteBool>(resultId);
+        return result;
     }
 
     void AutomationRemoteExtensionTarget::CallExtension(const winrt::AutomationRemoteGuid& extensionId, winrt::array_view<const winrt::AutomationRemoteObject> operands)
@@ -543,6 +562,13 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
 
         const auto result = Make<AutomationRemoteBool>(resultId);
         return result;
+    }
+
+    // AutomationRemoteConnectionBoundObject
+
+    AutomationRemoteConnectionBoundObject::AutomationRemoteConnectionBoundObject(bytecode::OperandId operandId, AutomationRemoteOperation & parent)
+    : base_type(operandId, parent)
+    {
     }
 
     // AutomationRemoteStringMap
@@ -964,5 +990,21 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     winrt::AutomationRemoteCacheRequest AutomationRemoteAnyObject::AsCacheRequest()
     {
         return As<AutomationRemoteCacheRequest>();
+    }
+
+    winrt::AutomationRemoteBool AutomationRemoteAnyObject::IsByteArray()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::IsByteArray{
+        resultId,
+        m_operandId
+        });
+        const auto result = Make<AutomationRemoteBool>(resultId);
+        return result;
+    }
+
+    winrt::AutomationRemoteByteArray AutomationRemoteAnyObject::AsByteArray()
+    {
+        return As<AutomationRemoteByteArray>();
     }
 }

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -16,7 +16,9 @@
 #include "AutomationRemoteArray.g.h"
 #include "AutomationRemoteStringMap.g.h"
 #include "AutomationRemoteCacheRequest.g.h"
+#include "AutomationRemoteByteArray.g.h"
 #include "AutomationRemoteElement.g.h"
+#include "AutomationRemoteConnectionBoundObject.g.h"
 #include "AutomationRemoteAnyObject.g.h"
 #include "AutomationRemoteExtensionTarget.g.h"
 #include "AutomationRemoteOperation.h"
@@ -523,11 +525,23 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteString Stringify();
     };
 
-     class AutomationRemoteExtensionTarget : public AutomationRemoteExtensionTargetT<AutomationRemoteExtensionTarget, AutomationRemoteObject>
+    class AutomationRemoteByteArray : public AutomationRemoteByteArrayT<AutomationRemoteByteArray, AutomationRemoteObject>
+    {
+    public:
+        AutomationRemoteByteArray(bytecode::OperandId operandId, AutomationRemoteOperation & parent);
+
+        void Set(const class_type & rhs)
+        {
+            AutomationRemoteObject::Set<AutomationRemoteByteArray>(rhs);
+        }
+    };
+
+    class AutomationRemoteExtensionTarget : public AutomationRemoteExtensionTargetT<AutomationRemoteExtensionTarget, AutomationRemoteObject>
     {
     public:
         AutomationRemoteExtensionTarget(bytecode::OperandId operandId, AutomationRemoteOperation& parent);
 
+        winrt::AutomationRemoteBool IsExtensionTarget();
         void CallExtension(const winrt::AutomationRemoteGuid& extensionId, winrt::array_view<const winrt::AutomationRemoteObject> operands);
         winrt::AutomationRemoteBool IsExtensionSupported(const winrt::AutomationRemoteGuid& extensionId);
     };
@@ -594,6 +608,17 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteElement Navigate(NavigateDirection direction);
     };
 
+    class AutomationRemoteConnectionBoundObject : public AutomationRemoteConnectionBoundObjectT<AutomationRemoteConnectionBoundObject, AutomationRemoteExtensionTarget>
+    {
+    public:
+        AutomationRemoteConnectionBoundObject(bytecode::OperandId operandId, AutomationRemoteOperation & parent);
+
+        void Set(const class_type & rhs)
+        {
+            AutomationRemoteObject::Set<AutomationRemoteConnectionBoundObject>(rhs);
+        }
+    };
+
     class AutomationRemoteAnyObject : public AutomationRemoteAnyObjectT<AutomationRemoteAnyObject, AutomationRemoteObject>
     {
     public:
@@ -627,6 +652,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteElement AsElement();
         winrt::AutomationRemoteBool IsCacheRequest();
         winrt::AutomationRemoteCacheRequest AsCacheRequest();
+        winrt::AutomationRemoteBool IsByteArray();
+        winrt::AutomationRemoteByteArray AsByteArray();
 
 #include "AutomationRemoteAnyObjectMethods.g.h"
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -528,9 +528,9 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     class AutomationRemoteByteArray : public AutomationRemoteByteArrayT<AutomationRemoteByteArray, AutomationRemoteObject>
     {
     public:
-        AutomationRemoteByteArray(bytecode::OperandId operandId, AutomationRemoteOperation & parent);
+        AutomationRemoteByteArray(bytecode::OperandId operandId, AutomationRemoteOperation& parent);
 
-        void Set(const class_type & rhs)
+        void Set(const class_type& rhs)
         {
             AutomationRemoteObject::Set<AutomationRemoteByteArray>(rhs);
         }
@@ -611,9 +611,9 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     class AutomationRemoteConnectionBoundObject : public AutomationRemoteConnectionBoundObjectT<AutomationRemoteConnectionBoundObject, AutomationRemoteExtensionTarget>
     {
     public:
-        AutomationRemoteConnectionBoundObject(bytecode::OperandId operandId, AutomationRemoteOperation & parent);
+        AutomationRemoteConnectionBoundObject(bytecode::OperandId operandId, AutomationRemoteOperation& parent);
 
-        void Set(const class_type & rhs)
+        void Set(const class_type& rhs)
         {
             AutomationRemoteObject::Set<AutomationRemoteConnectionBoundObject>(rhs);
         }


### PR DESCRIPTION
This PR implements all the wrappers specific to Custom Extensions. This includes ConnectionBoundObject wrappers, Byte/ByteArray wrappers and other wrappers specific to custom extensions.