### PR TITLE
UIA Operation Abstraction library: resolve any results alredy available before a remote unhandled exception

### DIFF
--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -2370,11 +2370,12 @@ namespace UiaOperationAbstraction
                 }
 
                 // Fetch bound results on success, but also
-                // instruction limit exceeded, 
+                // instruction limit exceeded and UnhandledException, 
                 // As we know certainly some of the remote operation did execute.
                 if (
                     status == winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::Success
                     || status == winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::InstructionLimitExceeded
+                    || status == winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationStatus::UnhandledException
                 )
                 {
                     for (auto& resolver : remoteOperationResolvers)


### PR DESCRIPTION
In pr #91, new exceptions were raised by scope.Resolve such as InstructionLimitExceeded and UnhandledException. In the case of InstructionLimitExceeded, any result variables already calculated before the limit was hit will be still resolved, making them available locally. 
This pr now resolves any possible variables for UnhandledException as well.
This now means that it is possible to track the progress of a remote operation either via remote logging for example, and even if an UnhandledException is raised from a COM call, or deliberately through a call to AbortOperationWithHresult, the variable/s holding the remote logging will still be available.
This then enables the pattern of failing fast in a remote operation much nicer, as you can just abort at any point but still have access to previous variables.
Tests for unhandledException have been added/updated to ensure result variables are resolved.
