### PR TITLE
Implement UiaConnectionBoundObject in abstraction API

### DIFF
--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -144,9 +144,10 @@ namespace Microsoft.UI.UIAutomation
 
     unsealed runtimeclass AutomationRemoteExtensionTarget : AutomationRemoteObject
     {
-        AutomationRemoteBool IsExtensionTarget();
+        /* Deprecated */ AutomationRemoteBool IsExtensionTarget();
         void CallExtension(AutomationRemoteGuid extensionId, AutomationRemoteObject[] operands);
         AutomationRemoteBool IsExtensionSupported(AutomationRemoteGuid extensionId);
+        void Set(AutomationRemoteExtensionTarget rhs);
     }
 
     runtimeclass AutomationRemoteArray : AutomationRemoteObject
@@ -268,6 +269,8 @@ namespace Microsoft.UI.UIAutomation
         AutomationRemoteCacheRequest AsCacheRequest();
         AutomationRemoteBool IsByteArray();
         AutomationRemoteByteArray AsByteArray();
+        AutomationRemoteBool IsExtensionTarget();
+        AutomationRemoteExtensionTarget AsExtensionTarget();
     }
 
     enum AutomationActiveEnd

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.cpp
@@ -694,7 +694,7 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     winrt::AutomationRemoteElement AutomationRemoteElement::GetUpdatedCacheElement(const winrt::AutomationRemoteCacheRequest& cacheRequest)
     {
         auto result = m_parent->NewNull().AsElement();
-        result.Set(*this);
+        result.Set(static_cast<winrt::AutomationRemoteElement>(*this));
         result.PopulateCache(cacheRequest);
         return result;
     }
@@ -1007,5 +1007,22 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     winrt::AutomationRemoteByteArray AutomationRemoteAnyObject::AsByteArray()
     {
         return As<AutomationRemoteByteArray>();
+    }
+
+    winrt::AutomationRemoteBool AutomationRemoteAnyObject::IsExtensionTarget()
+    {
+        const auto resultId = m_parent->GetNextId();
+        m_parent->InsertInstruction(bytecode::IsExtensionTarget{
+            resultId,
+            m_operandId
+        });
+
+        const auto result = Make<AutomationRemoteBool>(resultId);
+        return result;
+    }
+
+    winrt::AutomationRemoteExtensionTarget AutomationRemoteAnyObject::AsExtensionTarget()
+    {
+        return As<AutomationRemoteExtensionTarget>();
     }
 }

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Standins.h
@@ -541,9 +541,14 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
     public:
         AutomationRemoteExtensionTarget(bytecode::OperandId operandId, AutomationRemoteOperation& parent);
 
-        winrt::AutomationRemoteBool IsExtensionTarget();
+        /* Deprecated */ winrt::AutomationRemoteBool IsExtensionTarget();
         void CallExtension(const winrt::AutomationRemoteGuid& extensionId, winrt::array_view<const winrt::AutomationRemoteObject> operands);
         winrt::AutomationRemoteBool IsExtensionSupported(const winrt::AutomationRemoteGuid& extensionId);
+
+        void Set(const class_type& rhs)
+        {
+            AutomationRemoteObject::Set<AutomationRemoteExtensionTarget>(rhs);
+        }
     };
 
     struct AutomationRemoteStringMap : AutomationRemoteStringMapT<AutomationRemoteStringMap, Microsoft::UI::UIAutomation::implementation::AutomationRemoteObject>
@@ -654,6 +659,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         winrt::AutomationRemoteCacheRequest AsCacheRequest();
         winrt::AutomationRemoteBool IsByteArray();
         winrt::AutomationRemoteByteArray AsByteArray();
+        winrt::AutomationRemoteBool IsExtensionTarget();
+        winrt::AutomationRemoteExtensionTarget AsExtensionTarget();
 
 #include "AutomationRemoteAnyObjectMethods.g.h"
 

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.cpp
@@ -1045,6 +1045,25 @@ namespace UiaOperationAbstraction
         }
     }
 
+    void UiaOperationDelegator::ConvertVariantDataToRemote(std::variant<winrt::com_ptr<IUnknown>,
+        winrt::Microsoft::UI::UIAutomation::AutomationRemoteExtensionTarget>& localExtensionTargetVariant) const
+    {
+        if (m_useRemoteApi && m_remoteOperation)
+        {
+            if (auto localExtensionTarget = std::get_if<winrt::com_ptr<IUnknown>>(&localExtensionTargetVariant))
+            {
+                if (*localExtensionTarget)
+                {
+                    localExtensionTargetVariant = m_remoteOperation.ImportConnectionBoundObject(FromAbi<AutomationConnectionBoundObject>(localExtensionTarget->get()));
+                }
+                else
+                {
+                    localExtensionTargetVariant = m_remoteOperation.NewNull().AsExtensionTarget();
+                }
+            }
+        }
+    }
+
     void UiaOperationDelegator::ConvertVariantDataToRemote(std::variant<winrt::com_ptr<IUIAutomationElement>,
         winrt::Microsoft::UI::UIAutomation::AutomationRemoteElement>& localElementVariant) const
     {

--- a/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaOperationAbstraction.h
@@ -436,6 +436,9 @@ namespace UiaOperationAbstraction
             std::shared_ptr<wil::unique_variant>,
             winrt::Microsoft::UI::UIAutomation::AutomationRemoteObject>& localVariantVariant) const;
         void ConvertVariantDataToRemote(std::variant<
+            winrt::com_ptr<IUnknown>,
+            winrt::Microsoft::UI::UIAutomation::AutomationRemoteExtensionTarget>& localExtensionTargetVariant) const;
+        void ConvertVariantDataToRemote(std::variant<
             winrt::com_ptr<IUIAutomationElement>,
             winrt::Microsoft::UI::UIAutomation::AutomationRemoteElement>& localElementVariant) const;
         void ConvertVariantDataToRemote(std::variant<

--- a/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
+++ b/src/UIAutomation/UiaOperationAbstraction/UiaTypeAbstractionImpl.g.cpp
@@ -2008,24 +2008,24 @@
     }
 
     UiaTextRange::UiaTextRange(_In_ IUIAutomationTextRange* object):
-        UiaTypeBase(MakeWinrtComPtr(object))
+        UiaTypeBaseWithExtensionSupport(MakeWinrtComPtr(object))
     {
         ToRemote();
     }
 
     UiaTextRange::UiaTextRange(winrt::com_ptr<IUIAutomationTextRange> const& object):
-        UiaTypeBase(object)
+        UiaTypeBaseWithExtensionSupport(object)
     {
         ToRemote();
     }
 
     UiaTextRange::UiaTextRange(winrt::Microsoft::UI::UIAutomation::AutomationRemoteTextRange const& object):
-        UiaTypeBase(object)
+        UiaTypeBaseWithExtensionSupport(object)
     {
     }
 
     UiaTextRange::UiaTextRange(winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject const& object):
-        UiaTypeBase(object.AsTextRange())
+        UiaTypeBaseWithExtensionSupport(object.AsTextRange())
     {
     }
 
@@ -5031,24 +5031,24 @@
     }
 
     UiaElement::UiaElement(_In_ IUIAutomationElement* element):
-        UiaTypeBase(MakeWinrtComPtr(element))
+        UiaTypeBaseWithExtensionSupport(MakeWinrtComPtr(element))
     {
         ToRemote();
     }
 
     UiaElement::UiaElement(winrt::com_ptr<IUIAutomationElement> const& element):
-        UiaTypeBase(element)
+        UiaTypeBaseWithExtensionSupport(element)
     {
         ToRemote();
     }
 
     UiaElement::UiaElement(winrt::Microsoft::UI::UIAutomation::AutomationRemoteElement const& element):
-        UiaTypeBase(element)
+        UiaTypeBaseWithExtensionSupport(element)
     {
     }
 
     UiaElement::UiaElement(winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject const& element):
-        UiaTypeBase(element.AsElement())
+        UiaTypeBaseWithExtensionSupport(element.AsElement())
     {
     }
 
@@ -7224,16 +7224,71 @@
         return metadataValue;
     }
 
-    UiaBool UiaElement::IsExtensionSupported(UiaGuid guid)
+    UiaConnectionBoundObject::UiaConnectionBoundObject(_In_ IUnknown* target):
+        UiaTypeBaseWithExtensionSupport(MakeWinrtComPtr(target))
+    {
+        ToRemote();
+    }
+
+    UiaConnectionBoundObject::UiaConnectionBoundObject(winrt::com_ptr<IUnknown> const& target):
+        UiaTypeBaseWithExtensionSupport(target)
+    {
+        ToRemote();
+    }
+
+    UiaConnectionBoundObject::UiaConnectionBoundObject(winrt::Microsoft::UI::UIAutomation::AutomationRemoteExtensionTarget const& target):
+        UiaTypeBaseWithExtensionSupport(target)
+    {
+    }
+
+    UiaConnectionBoundObject::UiaConnectionBoundObject(winrt::Microsoft::UI::UIAutomation::AutomationRemoteAnyObject const& target):
+        UiaTypeBaseWithExtensionSupport(target.AsExtensionTarget())
+    {
+    }
+
+    UiaConnectionBoundObject& UiaConnectionBoundObject::operator=(const UiaConnectionBoundObject& other)
+    {
+        AssignCopyTo<UiaConnectionBoundObject>(m_member, other.m_member);
+        return *this;
+    }
+
+    UiaConnectionBoundObject::operator winrt::com_ptr<IUnknown>() const
+    {
+        return std::get<winrt::com_ptr<IUnknown>>(m_member);
+    }
+
+    UiaConnectionBoundObject::operator wil::com_ptr<IUnknown>() const
+    {
+        return wil::com_ptr<IUnknown>(std::get<winrt::com_ptr<IUnknown>>(m_member).get());
+    }
+
+    IUnknown* UiaConnectionBoundObject::get() const
+    {
+        return std::get<winrt::com_ptr<IUnknown>>(m_member).get();
+    }
+
+    void UiaConnectionBoundObject::reset()
+    {
+        std::get<winrt::com_ptr<IUnknown>>(m_member) = nullptr;
+    }
+
+    IUnknown** UiaConnectionBoundObject::operator&()
+    {
+        reset();
+        return std::get<winrt::com_ptr<IUnknown>>(m_member).put();
+    }
+
+    UiaBool UiaConnectionBoundObject::IsNull() const
     {
         if (UiaOperationAbstraction::ShouldUseRemoteApi())
         {
-            this->ToRemote();
-            guid.ToRemote();
-            auto remoteValue = std::get<winrt::Microsoft::UI::UIAutomation::AutomationRemoteElement>(m_member);
-            return remoteValue.IsExtensionSupported(guid);
+            auto remoteValue = std::get_if<AutomationRemoteExtensionTarget>(&m_member);
+            if (remoteValue)
+            {
+                return remoteValue->IsNull();
+            }
         }
 
-        // No local equivalent
-        throw winrt::hresult_not_implemented();
-    } 
+        return !get();
+    }
+


### PR DESCRIPTION
Partially implements #93

## Background
In pr #84  I added initial support for checking for and calling custom extensions to UiaElement through IsExtensionSupported and CallExtension methods.
However, this was somewhat incomplete, as UI Automation remote operations also allow for checking for and calling extensions on  text ranges, and generic connection-bound objects (which currently have no representation in the abstraction library at all).

The general pattern for custom extensions is usually:
* Given a UIA element or text range, call its CallExtension method with a custom pattern guid to fetch a custom pattern object. This custom pattern object is implemented on the provider side as a generic connection-bound object.
* On the connection-bound object representing the custom pattern, call its CallExtension method with a custom method guid to execute the required custom method on the pattern.

The work around would be to use a UiaElement in place of the connection-bound object, as that is the only class that implemented CallExtension. This is both semantically incorrect and dangerous (as calling any of the other UiaElement methods would fail or may crash the client.
 
PR #92  added support for connection-bound objects to the lower-level winrt library through the addition of the AutomationRemoteExtensionTarget class.
 
However, this also was slightly incomplete as AutomationRemoteExtensionTarget was missing a `Set` method, and AutomationRemoteAnyObject was missing IsExtensionTarget and AsExtensionTarget methods.

### Description of changes
This new PR enhances the abstraction library, adding a new UiaConnectionBoundObject class, which exposes IsExtensionSupported and CallExtension, and should be used where a connection-bound object is required, I.e. represents a custom pattern object. 
This PR also exposes IsExtensionSupported and CallExtension on UiaTextRange, completing all the places where custom extensions are supported.

The specific changes to the abstraction library are as follows:
* Add a UiaTypeBaseWithExtensionSupport template class which subclasses UiaTypeBase and adds IsExtensionSupported and CallExtension methods, moved from UiaElement.
* UiaElement and UiaTextRange now inherit from UiaTypeBaseWithExtensionSupport rather than UiaTypeBase. This makes IsExtensionSupported and CallExtension methods again available on UiaElement, but also now UiaTextRange.
* Add a new UiaConnectionBoundObject class, which inherits from UiaTypeBaseWithExtensionSupport. It contains no other real features of its own apart from being constructable from / convertable to AutomationRemoteExtensionTarget remotely and IUnknown locally. This can be used as a generic connection-bound object, such as sometimes returned from CallExtension, which represents a custom extension pattern.

The above work also required addressing the limitations of the AutomationRemoteExtensionTarget implementation in the winrt library. 

The specific changes to the winrt library are as follows:
* Add a 'Set' method to AutomationRemoteExtensionTarget.
* Add 'IsExtensionTarget' and 'AsExtensionTarget' methods to AutomationRemoteAnyObject to enable check / casting to AutomationRemoteExtensionTarget.
* Add a deprecation comment to AutomationRemoteExtensionTarget::IsExtensionTarget. I think this was a misunderstanding in PR #92 of where this needed to be.

### Testing
I have not yet added tests for these changes. I should be able to add some general tests for UiaConnectionBoundObject in regards to construction / conversions. But as mentioned in previous PRs, there is currently no simple way to test IsExtesnionSupported / CallExtension as this requires a provider that has implemented these.

### Questions / thoughts
1. I wonder whether having UiaConnectionBoundObject's local type  as IUnknown is suitable. It seems like the only choice, as the older COM interfaces don't have a representation for connection-bound objects E.g. a IUIAutomationconnectionBoundObject. Thus IUnknown really is the only valid representation. But are there any disadvantages to this. Are there features or conversions  of UiaConnectionBoundObject that we should deliberately remove or disable as IUnknown is so generic? I can't think of any so far. But just bringing up the point here in case. 
2. Am I right that IsExtensionTarget on AutomationRemoteExtensionTarget was an error? Can someone please verify that the IsExtensionTarget op code in the remote ops VM really does ask if an anyObject is an extensionTarget (similar to all the other Is* op codes)?
3. in the winrt library, standins.cpp, AutomationRemoteElement::GetUpdatedCacheElement: it was necessary for me to static_cast the `*this` parameter on result.Set to AutomationRemoteElement, otherwise I would get an ambiguous overload error when compiling. This was caused due to me adding a `Set` method to AutomationRemoteExtensionTarget, which is inherited by AutomationRemoteElement. I don't entirely understand why the static_cast is necessary or why the compiler is clearly converting to a base class when searching for the correct overload of `Set`. Did I address this issue in the right way? 
