### PR TITLE
Expose platform AutomationRemoteOperationResult from ResultSet

### DIFF
--- a/src/UIAutomation/FunctionalTests/WinRTBuilderTests.cpp
+++ b/src/UIAutomation/FunctionalTests/WinRTBuilderTests.cpp
@@ -33,6 +33,10 @@ namespace WinRTBuilderTests
 
             auto results = op.Execute();
             AssertSucceeded(results.OperationStatus());
+
+            auto platformResult = results.PlatformResult();
+            Assert::IsTrue(results.Status() == platformResult.Status());
+
             auto name = winrt::unbox_value<winrt::hstring>(results.GetResult(nameToken));
 
             Assert::AreEqual(winrt::hstring(L"Display is 0"), name);

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperationResultSet.cpp
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperationResultSet.cpp
@@ -36,6 +36,11 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
         return m_result.ExtendedError();
     }
 
+    winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationResult AutomationRemoteOperationResultSet::PlatformResult()
+    {
+        return m_result;
+    }
+
     bool AutomationRemoteOperationResultSet::HasResult(Microsoft::UI::UIAutomation::AutomationRemoteOperationResponseToken const& token)
     {
         return m_result.HasOperand({ token.Value });

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperationResultSet.h
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/AutomationRemoteOperationResultSet.h
@@ -43,6 +43,8 @@ namespace winrt::Microsoft::UI::UIAutomation::implementation
 
         winrt::hresult ExtendedError();
 
+        winrt::Windows::UI::UIAutomation::Core::AutomationRemoteOperationResult PlatformResult();
+
         bool HasResult(winrt::AutomationRemoteOperationResponseToken const& token);
         winrt::IInspectable GetResult(winrt::AutomationRemoteOperationResponseToken const& token);
 

--- a/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
+++ b/src/UIAutomation/Microsoft.UI.UIAutomation/Microsoft.UI.UIAutomation.idl
@@ -196,6 +196,7 @@ namespace Microsoft.UI.UIAutomation
         HRESULT OperationStatus{ get; };
         Windows.UI.UIAutomation.Core.AutomationRemoteOperationStatus Status{ get; };
         HRESULT ExtendedError{ get; };
+        Windows.UI.UIAutomation.Core.AutomationRemoteOperationResult PlatformResult{ get; };
         Boolean HasResult(AutomationRemoteOperationResponseToken token);
         IInspectable GetResult(AutomationRemoteOperationResponseToken token);
     }


### PR DESCRIPTION
## Description

Expose the underlying platform `Windows.UI.UIAutomation.Core.AutomationRemoteOperationResult` from `AutomationRemoteOperationResultSet` through a read-only `PlatformResult` property.

This gives callers direct access to the richer diagnostic information held by the platform result while keeping the existing convenience APIs unchanged.

Changes:
- add `PlatformResult` to the WinRT IDL surface
- return the existing internal `m_result` object
- add functional coverage that accesses the platform result and compares its status

Fixes #46

## Testing

- `git -c core.whitespace=cr-at-eol diff --check upstream/main..HEAD` - passed
- functional coverage added in `WinRTBuilderTests.cpp`
- full local build not run because this legacy project requires the matching Windows Insider Preview SDK / Visual C++ toolchain